### PR TITLE
Lorenz reader improvements.

### DIFF
--- a/source/cpp/lorenz_ode/lorenz.hpp
+++ b/source/cpp/lorenz_ode/lorenz.hpp
@@ -81,6 +81,12 @@ public:
     lorenz(std::vector<std::array<Real, 7>> && state) : state_{std::move(state)}
     {};
 
+    // Potential unit test: ICS {x(0), y(0), z(0)} = {0,0,C} => x(t) = 0, y(t) = 0, z(t) = Cexp(-βt).
+    std::array<Real, 3> operator()(Real t) const {
+        Real nan = std::numeric_limits<Real>::quiet_NaN();
+        return {nan, nan, nan};
+    }
+
     const std::vector<std::array<Real, 7>>& state() const {
         return state_;
     }

--- a/source/cpp/lorenz_ode/lorenz_reader.cpp
+++ b/source/cpp/lorenz_ode/lorenz_reader.cpp
@@ -5,53 +5,86 @@
 #include <adios2.h>
 #include "lorenz.hpp"
 
-int main()
+void read_solution()
 {
     using Real = double;
     adios2::ADIOS adios;
     adios2::IO io = adios.DeclareIO("myio");
     adios2::Engine adios_engine = io.Open("lorenz.bp", adios2::Mode::Read);
     auto sigma_att = io.InquireAttribute<Real>("σ");
+    std::cout << "Simulation performed with ";
     if (sigma_att) {
         Real sigma = sigma_att.Data()[0];
-        std::cout << "σ = " << sigma << "\n";
+        std::cout << "σ = " << sigma << ", ";
     }
 
     auto beta_att = io.InquireAttribute<Real>("β");
     if (beta_att) {
         Real beta = beta_att.Data()[0];
-        std::cout << "β = " << beta << "\n";
+        std::cout << "β = " << beta << ", ";
     }
 
     auto rho_att = io.InquireAttribute<Real>("ρ");
     if (rho_att) {
         Real rho = rho_att.Data()[0];
-        std::cout << "ρ = " << rho << "\n";
+        std::cout << "and ρ = " << rho << ".\n";
     }
 
     auto interpretation_att = io.InquireAttribute<std::string>("interpretation");
     if (interpretation_att) {
         std::string interpretation = interpretation_att.Data()[0];
-        std::cout << "Interpretation: " << interpretation << "\n";
+        std::cout << "The data should be interpreted as a " << interpretation << ".\n";
     }
 
     auto absolute_error_att = io.InquireAttribute<Real>("‖û-u‖");
     if (absolute_error_att) {
-        std::cout << "Solutions computed with absolute error goal of " << absolute_error_att.Data()[0] << "\n";
+        std::cout << "Solutions were computed with an absolute error goal of " << absolute_error_att.Data()[0] << "\n";
     }
 
-    size_t paths = 2;
+    // Check that std::vector<std::array<Real, 7>> has the proper memory layout.
+    static_assert(sizeof(std::array<Real, 7>)==7*sizeof(Real),
+                  "The std::array on your system does not have the proper layout to be correctly deserialized in ADIOS2.");
+
+
     std::vector<std::array<Real, 7>> v;
-    for (size_t i = 0; i < paths; ++i) {
-        for (size_t j = 0; j < paths; ++j) {
-            for (size_t k = 0; k < paths; ++k) {
-                std::string variable = "u" + std::to_string(i) + std::to_string(j) + std::to_string(k);
-                auto state_variable = io.InquireVariable<Real>(variable);
-                if (state_variable) {
-                    std::cout << "We have state variable " << variable << "\n";
-                }
-            }
+    auto const & m = io.AvailableVariables();
+    for (auto const & [key, val] : io.AvailableVariables())
+    {
+        auto state_variable = io.InquireVariable<Real>(key);
+        if (!state_variable) {
+            std::cerr << "We do not have a state variable " << key << "\n";
+            continue;
         }
+        const auto shape = state_variable.Shape();
+        if (shape.size() != 1) {
+            std::cerr << "Expected 1D layout.\n";
+            continue;
+        }
+        if ((shape[0] % 7) != 0) {
+            std::cerr << "The size of a 7D array of structs must be a multiple of 7.\n";
+            continue;
+        }
+        size_t states = shape[0]/7;
+        if (v.capacity() < states) {
+            v.reserve(states);
+        }
+
+        double* d = v[0].data();
+        adios_engine.Get(key, d, adios2::Mode::Sync);
     }
     adios_engine.Close();
+}
+
+int main()
+{
+    try
+    {
+        read_solution();
+    }
+    catch (std::exception const & e)
+    {
+        std::cerr << "Caught exception reading Lorenz ODE solution: " << e.what() << "\n";
+        return 1;
+    }
+    return 0;
 }

--- a/source/cpp/lorenz_ode/lorenz_reader.cpp
+++ b/source/cpp/lorenz_ode/lorenz_reader.cpp
@@ -77,13 +77,15 @@ void read_solution()
             std::cerr << "The size of a 7D array of structs must be a multiple of 7.\n";
             continue;
         }
-        size_t states = shape[0]/7;
-        std::vector<std::array<Real, 7>> v(states);
+        size_t num_states = shape[0]/7;
+        std::vector<std::array<Real, 7>> v(num_states);
         adios_engine.Get(key, v[0].data(), adios2::Mode::Sync);
 
         auto solution = lorenz(std::move(v));
-        std::array<Real, 3> u = solution(solution.tmax());
-        std::cout << "Last position is u(" << solution.tmax() << ") = {" << u[0] << ", " << u[1] << ", " << u[2] << "}\n";
+        std::array<Real, 3> u = solution(Real(0));
+        std::cout << "First position is u(0) = {" << u[0] << ", " << u[1] << ", " << u[2] << "}\n";
+        u = solution(solution.tmax());
+        std::cout << "Last position is u(" << solution.tmax() << ") = {" << u[0] << ", " << u[1] << ", " << u[2] << "}\n\n\n";
         // For more information than we want:
         // std::cout << solution << "\n";
 

--- a/source/cpp/lorenz_ode/lorenz_reader.cpp
+++ b/source/cpp/lorenz_ode/lorenz_reader.cpp
@@ -69,6 +69,14 @@ void read_solution()
 
         double* d = v[0].data();
         adios_engine.Get(key, d, adios2::Mode::Sync);
+        std::vector<Real> times(v.size());
+        for (size_t i = 0; i < v.size(); ++i) {
+            times[i] = v[i][0];
+        }
+        // One property of the data:
+        if (!std::is_sorted(times.begin(), times.end())) {
+            std::cerr << "Times should be sorted in increasing order t0 < t1 < ... < tn\n";
+        }
     }
     adios_engine.Close();
 }

--- a/source/cpp/lorenz_ode/lorenz_reader.cpp
+++ b/source/cpp/lorenz_ode/lorenz_reader.cpp
@@ -65,9 +65,7 @@ void read_solution()
             continue;
         }
         size_t states = shape[0]/7;
-        if (v.capacity() < states) {
-            v.reserve(states);
-        }
+        v.resize(states);
 
         double* d = v[0].data();
         adios_engine.Get(key, d, adios2::Mode::Sync);

--- a/source/cpp/lorenz_ode/lorenz_writer.cpp
+++ b/source/cpp/lorenz_ode/lorenz_writer.cpp
@@ -34,17 +34,16 @@ void solve_lorenz_ivp()
                 auto solution = lorenz<double>(sigma, beta, rho, initial_conditions, tmax, absolute_error);
                 auto const & skeleton = solution.state();
                 // This is just being *ultra* cautious; this double checks that the memory layout is contiguous.
+                const double * const p = skeleton[0].data();
                 for (size_t i = 0; i < skeleton.size(); ++i) {
-                    const double * const p = skeleton[0].data();
                     for (size_t j = 0; j < 7; ++j) {
                         assert(skeleton[i][j] == p[7*i+j]);
                     }
                 }
+
                 const std::string variable = "u" + std::to_string(i) + std::to_string(j) + std::to_string(k);
                 auto state_variable = io.DefineVariable<Real>(variable, {7*skeleton.size()}, {0}, {7*skeleton.size()}, adios2::ConstantDims);
-                adios_engine.BeginStep();
-                adios_engine.Put(state_variable, skeleton[0].data());
-                adios_engine.EndStep();
+                adios_engine.Put(state_variable, p, adios2::Mode::Sync);
             }
         }
     }

--- a/source/cpp/lorenz_ode/lorenz_writer.cpp
+++ b/source/cpp/lorenz_ode/lorenz_writer.cpp
@@ -32,7 +32,7 @@ void solve_lorenz_ivp()
             for (size_t k = 0; k < paths; ++k) {
                 const std::array<Real, 3> initial_conditions{Real(i),Real(j),Real(k)};
                 auto solution = lorenz<double>(sigma, beta, rho, initial_conditions, tmax, absolute_error);
-                auto const & skeleton = solution.state();
+                auto const & skeleton = solution.states();
                 // This is just being *ultra* cautious; this double checks that the memory layout is contiguous.
                 const double * const p = skeleton[0].data();
                 for (size_t i = 0; i < skeleton.size(); ++i) {

--- a/source/cpp/lorenz_ode/lorenz_writer.cpp
+++ b/source/cpp/lorenz_ode/lorenz_writer.cpp
@@ -40,7 +40,6 @@ void solve_lorenz_ivp()
                         assert(skeleton[i][j] == p[7*i+j]);
                     }
                 }
-
                 const std::string variable = "u" + std::to_string(i) + std::to_string(j) + std::to_string(k);
                 auto state_variable = io.DefineVariable<Real>(variable, {7*skeleton.size()}, {0}, {7*skeleton.size()}, adios2::ConstantDims);
                 adios_engine.Put(state_variable, p, adios2::Mode::Sync);
@@ -58,5 +57,14 @@ int main() {
     catch (std::exception const & e)
     {
         std::cerr << "Caught an exception solving Lorenz ODE: " << e.what() << "\n";
+    }
+
+    try
+    {
+        test_lorenz<double>();
+    }
+    catch (std::exception const & e)
+    {
+        std::cout << "Caught and exception from the Lorenz unit tests: " << e.what() << "\n";
     }
 }


### PR DESCRIPTION
Ok friends, got a quick and hopefully easy problem with this one:

Whenever I run this, I hit an exception:

```
➜  build git:(lorenz_ode) ✗ ./bin/lorenz_reader 
Simulation performed with σ = 10, β = 2.66667, and ρ = 28.
The data should be interpreted as a 7D array of structs {tᵢ, xᵢ, yᵢ, zᵢ, ẋᵢ, ẏᵢ, żᵢ}.
Solutions were computed with an absolute error goal of 1e-05
Caught exception reading Lorenz ODE solution: ERROR: offset 0 from steps start 1 in variable u001 is beyond the largest available step = 1, check Variable SetStepSelection argument stepsCount (random access), or number of BeginStep calls (streaming), in call to Get
```

If I add a `BeginStep()`/`EndStep()` i.e.,

```
double* d = v[0].data();
adios_engine.BeginStep();
adios_engine.Get(key, d, adios2::Mode::Sync);
adios_engine.EndStep();
```

it gets even weirder:

```
➜  build git:(lorenz_ode) ✗ ./bin/lorenz_reader 
Simulation performed with σ = 10, β = 2.66667, and ρ = 28.
The data should be interpreted as a 7D array of structs {tᵢ, xᵢ, yᵢ, zᵢ, ẋᵢ, ẏᵢ, żᵢ}.
Solutions were computed with an absolute error goal of 1e-05
We do not have a state variable u001
We do not have a state variable u010
We do not have a state variable u011
We do not have a state variable u100
We do not have a state variable u101
We do not have a state variable u110
We do not have a state variable u111
```