### PR TITLE
degrade sphinx version to 3.0.4 because breathe 4.18.1 depends on Sph…

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ pytz==2019.3
 requests==2.23.0
 six==1.14.0
 snowballstemmer==2.0.0
-Sphinx==3.1.2
+Sphinx==3.0.4
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-blockdiag==2.0.0


### PR DESCRIPTION
…inx<3.1 and >=3.0