### PR TITLE
Add GrayScott.jl Julia port of Gray Scott example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 .settings/
 .pydevproject
 
+# VS Code
+.vscode/
+
 #binary, library, or temporary build files
 *.o
 *.a
@@ -26,3 +29,7 @@ build*/
 
 # Mac OSX finder-related files
 .DS_Store
+
+# julia
+Manifest.toml
+

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,9 @@ source/cpp:  C++ low-level and high-level API examples
     - [variables-shapes-hl.cpp](https://github.com/ornladios/ADIOS2-Examples/blob/master/source/cpp/basics/variables-shapes-hl.cpp) variables shapes support in adios2 C++ high-level API
 
 
-- [gray-scott](https://github.com/ornladios/ADIOS2-Examples/blob/master/source/cpp/gray-scott/): 3D reaction diffusion simulation in C++, includes C++ and Python analisys code. 
+- [gray-scott](https://github.com/ornladios/ADIOS2-Examples/blob/master/source/cpp/gray-scott/): 3D reaction diffusion simulation in C++, includes C++ and Python analisys code.
+
+- [GrayScott.jl](https://github.com/ornladios/ADIOS2-Examples/blob/master/source/julia/GrayScott.jl): 3D reaction diffusion simulation in Julia with either CPU threads, CUDA.jl or AMDGPU.jl (AMD GPU random number generation is work-in-progress) back ends and analisys code (also work in progress). Uses [ADIOS2.jl](https://github.com/eschnett/ADIOS2.jl) Julia bindings.
 
 source/c: C API examples
 - hello-world: write and reads a simple greeting

--- a/source/cpp/gray-scott/README.md
+++ b/source/cpp/gray-scott/README.md
@@ -4,7 +4,7 @@ This is a 3D 7-point stencil code to simulate the following [Gray-Scott
 reaction diffusion model](https://doi.org/10.1126/science.261.5118.189):
 
 ```
-u_t = Du * (u_xx + u_yy + u_zz) - u * v^2 + F * (1 - u)
+u_t = Du * (u_xx + u_yy + u_zz) - u * v^2 + F * (1 - u)  + noise * randn(-1,1)
 v_t = Dv * (v_xx + v_yy + v_zz) + u * v^2 - (F + k) * v
 ```
 

--- a/source/julia/GrayScott.jl/.JuliaFormatter.toml
+++ b/source/julia/GrayScott.jl/.JuliaFormatter.toml
@@ -1,3 +1,4 @@
 margin = 80
 join_lines_based_on_source = true
 style = "sciml"
+format_doctrings = true

--- a/source/julia/GrayScott.jl/.JuliaFormatter.toml
+++ b/source/julia/GrayScott.jl/.JuliaFormatter.toml
@@ -1,0 +1,3 @@
+margin = 80
+join_lines_based_on_source = true
+style = "sciml"

--- a/source/julia/GrayScott.jl/Project.toml
+++ b/source/julia/GrayScott.jl/Project.toml
@@ -5,4 +5,5 @@ version = "0.1.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/source/julia/GrayScott.jl/Project.toml
+++ b/source/julia/GrayScott.jl/Project.toml
@@ -1,0 +1,8 @@
+name = "GrayScott"
+uuid = "089a57ea-382b-4fd7-9f05-24902db6ec52"
+authors = ["William F Godoy <williamfgc@yahoo.com>"]
+version = "0.1.0"
+
+[deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/source/julia/GrayScott.jl/Project.toml
+++ b/source/julia/GrayScott.jl/Project.toml
@@ -4,6 +4,15 @@ authors = ["William F Godoy <williamfgc@yahoo.com>"]
 version = "0.1.0"
 
 [deps]
+ADIOS2 = "e0ce9d3b-0dbd-416f-8264-ccca772f60ec"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+PProf = "e4faabce-9ead-11e9-39d9-4379958e3056"
+Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[compat]
+julia = "1.8"

--- a/source/julia/GrayScott.jl/Project.toml
+++ b/source/julia/GrayScott.jl/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ADIOS2 = "e0ce9d3b-0dbd-416f-8264-ccca772f60ec"
+AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/source/julia/GrayScott.jl/ReadMe.md
+++ b/source/julia/GrayScott.jl/ReadMe.md
@@ -1,0 +1,139 @@
+# ADIOS2-Examples GrayScott.jl
+
+Julia version of [the gray-scott C++ and Python](https://github.com/ornladios/ADIOS2-Examples/blob/master/source/cpp/gray-scott/)
+example. 
+
+This is a 3D 7-point stencil code to simulate the following [Gray-Scott
+reaction diffusion model](https://doi.org/10.1126/science.261.5118.189):
+
+```
+u_t = Du * (u_xx + u_yy + u_zz) - u * v^2 + F * (1 - u) + noise * randn(-1,1)
+v_t = Dv * (v_xx + v_yy + v_zz) + u * v^2 - (F + k) * v
+```
+
+This version contains: 
+
+- CPU threaded solver using Julia's [multithreading]](https://docs.julialang.org/en/v1/manual/multi-threading/)
+- GPU solvers using [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl), [AMDGPU.jl](https://github.com/JuliaGPU/AMDGPU.jl)
+- Parallel I/O using the [ADIOS2.jl](https://github.com/eschnett/ADIOS2.jl) Julia bindings to [ADIOS2](https://github.com/ornladios/ADIOS2)
+- Message passing interface (MPI) using [MPI.jl](https://github.com/JuliaParallel/MPI.jl) Julia bindings to MPI
+- Easily switch between float- (Float32) and double- (Float64) precision in the configuration file
+
+## How to run
+
+Currently only the simulation part is ported from C++, the data analysis is work-in-progress. 
+
+Pre-requisities:
+
+- A recent Julia version: v1.8.5 or v1.9.0-beta3 as of January 2023 from [julialang.org/downloads](https://julialang.org/downloads/)
+
+### Run locally 
+
+1. **Set up dependencies**
+
+From the `GrayScott.jl` directory instantiate and use MPI artifact jll (preferred method). 
+To use a system provided MPI, see [here](https://juliaparallel.org/MPI.jl/latest/configuration/#using_system_mpi)
+
+```julia
+
+$ julia --project
+
+Julia REPL
+
+julia> ]  
+
+(GrayScott.jl)> instantiate
+...
+(GrayScott.jl)> <-
+julia> using MPIPreferences
+julia> MPIPreferences.use_jll_binary()
+julia> exit()
+```
+
+Julia manages its own packages using [Pkg.jl](https://pkgdocs.julialang.org/v1/), the above would create platform-specific `LocalPreferences.toml` and `Manifest.toml` files.
+
+2. **Set up the examples/settings-files.json configuration file**
+
+```
+{
+    "L": 64,
+    "Du": 0.2,
+    "Dv": 0.1,
+    "F": 0.02,
+    "k": 0.048,
+    "dt": 1.0,
+    "plotgap": 10,
+    "steps": 10000,
+    "noise": 0.1,
+    "output": "gs-julia-1MPI-64L-F32.bp",
+    "checkpoint": false,
+    "checkpoint_freq": 700,
+    "checkpoint_output": "ckpt.bp",
+    "restart": false,
+    "restart_input": "ckpt.bp",
+    "adios_config": "adios2.xml",
+    "adios_span": false,
+    "adios_memory_selection": false,
+    "mesh_type": "image",
+    "precision": "Float32",
+    "backend": "CPU"
+}
+
+```
+
+The file is nearly identical to the C++ original example. 
+Not all options are currently supported, but two Julia-only options are added: 
+
+    - "precision": either Float32 or Float64 in the array simulation (including GPUs)
+    - "backend": "CPU", "CUDA" or "AMDGPU"
+
+3. **Running the simulation**
+
+- `CPU threads`: launch julia assigning a number of threads (e.g. -t 8):
+
+    ```
+    $ julia --project -t 8 gray-scott.jl examples/settings-files.json
+    ```
+
+- `CUDA/AMDGPU`: set the "backend" option in examples/settings-files.json to either "CUDA" or "AMDGPU"
+
+    ```
+    $ julia --project gray-scott.jl examples/settings-files.json
+    ```
+
+This would generate an adios2 file from the output entry in the configuration file (e.g. `gs-julia-1MPI-64L-F32.bp`)
+that can be visualized with ParaView with either the VTX or the FIDES readers.
+**Important**: the AMDGPU.jl implementation of `randn` is currently work in progress. 
+See related issue [here](https://github.com/JuliaGPU/AMDGPU.jl/issues/378)
+
+
+4. **Running on OLCF Summit and Crusher systems**
+The code was tested on the Oak Ridge National Laboratory Leadership Computing Facilities (OLCF): [Summit](https://docs.olcf.ornl.gov/systems/summit_user_guide.html) and [Crusher](https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html). Both are used testing a recent version of Julia [v1.9.0-beta3](https://julialang.org/downloads/#upcoming_release) and a `JULIA_DEPOT_PATH` is required to install packages and artifacts. **DO NOT USE your home directory**. We are providing configuration scripts in `scripts/config_XXX.sh` showing the plumming required for these systems. They need to be executed only once per session from the login nodes. 
+
+To reuse these file the first 3 entries must be modified and run on login-nodes and the PATH poiting at a downloaded Julia binary for the corresponding PowerPC (Summit) and x86-64 (Crusher) architectures. Only "CPU" and "CUDA" backends are supported on Summit, while "CPU" and "AMDGPU" backends are supported on Crusher.
+
+    ```
+    # Replace these 3 entries
+    PROJ_DIR=/gpfs/alpine/proj-shared/csc383
+    export JULIA_DEPOT_PATH=$PROJ_DIR/etc/summit/julia_depot
+    GS_DIR=$PROJ_DIR/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl
+    ...
+    # and the path 
+    export PATH=$PROJ_DIR/opt/summit/julia-1.9.0-beta3/bin:$PATH
+    ```
+
+## To-do list
+
+  1. Add support including random number on device kernel code on `AMDGPU.jl`
+  2. Set the domain size `L` in the configuration file as a multiple of 6 for Summit, and a multiple of 4 on Crusher
+  3. Add data analysis: PDF for u and v and Julia 2D plotting capabilities: Plots.jl, Makie.jl
+  4. Add interactive computing with Pluto.jl notebooks
+
+
+## Acknowledgements
+This research was supported by the Exascale Computing Project (17-SC-20-SC), a joint project of the U.S. Department of Energy’s Office of Science and National Nuclear Security Administration, responsible for delivering a capable exascale ecosystem, including software, applications, and hardware technology, to support the nation’s exascale computing imperative. 
+
+This research used resources of the Oak Ridge Leadership Computing Facility at the Oak Ridge National Laboratory, which is supported by the Office of Science of the U.S. Department of Energy under Contract No. DE-AC05-00OR22725.
+
+Thanks to the Exascale Computing Project PROTEAS-TUNE and ADIOS subprojects, and the ASCR Bluestone.
+Thanks to all the Julia community members, packages developers and maintainers for their great work.

--- a/source/julia/GrayScott.jl/examples/settings-files.json
+++ b/source/julia/GrayScott.jl/examples/settings-files.json
@@ -1,0 +1,21 @@
+{
+    "L": 64,
+    "Du": 0.2,
+    "Dv": 0.1,
+    "F": 0.01,
+    "k": 0.05,
+    "dt": 2.0,
+    "plotgap": 10,
+    "steps": 1000,
+    "noise": 0.0000001,
+    "output": "gs.bp",
+    "checkpoint": true,
+    "checkpoint_freq": 700,
+    "checkpoint_output": "ckpt.bp",
+    "restart": false,
+    "restart_input": "ckpt.bp",
+    "adios_config": "adios2.xml",
+    "adios_span": false,
+    "adios_memory_selection": false,
+    "mesh_type": "image"
+}

--- a/source/julia/GrayScott.jl/examples/settings-files.json
+++ b/source/julia/GrayScott.jl/examples/settings-files.json
@@ -1,14 +1,14 @@
 {
-    "L": 512,
+    "L": 64,
     "Du": 0.2,
     "Dv": 0.1,
     "F": 0.02,
     "k": 0.048,
     "dt": 1.0,
-    "plotgap": 200,
+    "plotgap": 10,
     "steps": 10000,
     "noise": 0.1,
-    "output": "gs-julia-1MPI-512L.bp",
+    "output": "gs-julia-1MPI-64L-F32.bp",
     "checkpoint": false,
     "checkpoint_freq": 700,
     "checkpoint_output": "ckpt.bp",
@@ -19,5 +19,5 @@
     "adios_memory_selection": false,
     "mesh_type": "image",
     "precision": "Float32",
-    "backend": "CUDA"
+    "backend": "CPU"
 }

--- a/source/julia/GrayScott.jl/examples/settings-files.json
+++ b/source/julia/GrayScott.jl/examples/settings-files.json
@@ -1,15 +1,15 @@
 {
-    "L": 64,
+    "L": 512,
     "Du": 0.2,
     "Dv": 0.1,
-    "F": 0.01,
-    "k": 0.05,
-    "dt": 2.0,
-    "plotgap": 10,
-    "steps": 1000,
-    "noise": 0.0000001,
-    "output": "gs.bp",
-    "checkpoint": true,
+    "F": 0.02,
+    "k": 0.048,
+    "dt": 1.0,
+    "plotgap": 200,
+    "steps": 10000,
+    "noise": 0.1,
+    "output": "gs-julia-1MPI-512L.bp",
+    "checkpoint": false,
     "checkpoint_freq": 700,
     "checkpoint_output": "ckpt.bp",
     "restart": false,
@@ -17,5 +17,7 @@
     "adios_config": "adios2.xml",
     "adios_span": false,
     "adios_memory_selection": false,
-    "mesh_type": "image"
+    "mesh_type": "image",
+    "precision": "Float32",
+    "backend": "CUDA"
 }

--- a/source/julia/GrayScott.jl/gray-scott.jl
+++ b/source/julia/GrayScott.jl/gray-scott.jl
@@ -1,0 +1,15 @@
+import GrayScott
+
+# using Profile
+# using PProf
+
+function julia_main()::Cint
+    GrayScott.main(ARGS)
+    return 0
+end
+
+if !isdefined(Base, :active_repl)
+    @time julia_main()
+    # @profile julia_main()
+    # pprof()
+end

--- a/source/julia/GrayScott.jl/scripts/config_crusher.sh
+++ b/source/julia/GrayScott.jl/scripts/config_crusher.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+PROJ_DIR=/gpfs/alpine/proj-shared/csc383
+export JULIA_DEPOT_PATH=$PROJ_DIR/etc/crusher/julia_depot
+GS_DIR=$PROJ_DIR/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl
+
+# remove existing generated Manifest.toml
+rm -f $GS_DIR/Manifest.toml
+rm -f $GS_DIR/LocalPreferences.toml
+
+module purge
+
+# load required modules
+module load PrgEnv-cray/8.3.3 # has required gcc
+module load cray-mpich
+module load rocm/5.4.0
+module load adios2 # only works with PrgEnv-cray
+
+# existin julia 1.6 module is outdated 
+export PATH=$PROJ_DIR/opt/crusher/julia-1.9.0-beta3/bin:$PATH
+#export LD_LIBRARY_PATH=$OLCF_JULIA_ROOT/lib/julia:$LD_LIBRARY_PATH
+
+# Required to point at underlying modules above
+export JULIA_AMDGPU_DISABLE_ARTIFACTS=1
+# Required to enable underlying ADIOS2 library from loaded module
+export JULIA_ADIOS2_PATH=$OLCF_ADIOS2_ROOT
+
+
+# Set up Julia packages pointing at the relative location of Project.toml
+# MPIPreferences to use spectrum-mpi
+julia --project=$GS_DIR -e 'using Pkg; Pkg.add("MPIPreferences")'
+julia --project=$GS_DIR -e 'using MPIPreferences; MPIPreferences.use_system_binary(; library_names=["libmpi_cray"], mpiexec="srun")'
+
+# Instantiate the project by installing packages in Project.toml
+julia --project=$GS_DIR -e 'using Pkg; Pkg.instantiate()'
+
+# Adds a custom branch in case the development version is needed (for devs to test new features)
+julia --project=$GS_DIR -e 'using Pkg; Pkg.add(url="https://github.com/eschnett/ADIOS2.jl.git", rev="main")'
+
+# Build the new ADIOS2
+julia --project=$GS_DIR -e 'using Pkg; Pkg.build()'
+julia --project=$GS_DIR -e 'using Pkg; Pkg.precompile()'

--- a/source/julia/GrayScott.jl/scripts/config_crusher.sh
+++ b/source/julia/GrayScott.jl/scripts/config_crusher.sh
@@ -8,6 +8,7 @@ GS_DIR=$PROJ_DIR/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl
 rm -f $GS_DIR/Manifest.toml
 rm -f $GS_DIR/LocalPreferences.toml
 
+# good practice to avoid conflicts with existing default modules
 module purge
 
 # load required modules
@@ -16,20 +17,20 @@ module load cray-mpich
 module load rocm/5.4.0
 module load adios2 # only works with PrgEnv-cray
 
-# existin julia 1.6 module is outdated 
+# existing julia 1.6 module is outdated 
 export PATH=$PROJ_DIR/opt/crusher/julia-1.9.0-beta3/bin:$PATH
-#export LD_LIBRARY_PATH=$OLCF_JULIA_ROOT/lib/julia:$LD_LIBRARY_PATH
 
 # Required to point at underlying modules above
 export JULIA_AMDGPU_DISABLE_ARTIFACTS=1
 # Required to enable underlying ADIOS2 library from loaded module
 export JULIA_ADIOS2_PATH=$OLCF_ADIOS2_ROOT
 
-
-# Set up Julia packages pointing at the relative location of Project.toml
 # MPIPreferences to use spectrum-mpi
 julia --project=$GS_DIR -e 'using Pkg; Pkg.add("MPIPreferences")'
 julia --project=$GS_DIR -e 'using MPIPreferences; MPIPreferences.use_system_binary(; library_names=["libmpi_cray"], mpiexec="srun")'
+
+# Regression being fixed with CUDA v4.0.0. CUDA.jl does lazy loading for portability to systems without NVIDIA GPUs
+julia --project=$GS_DIR -e 'using Pkg; Pkg.add(name="CUDA", version="v3.13.1")' 
 
 # Instantiate the project by installing packages in Project.toml
 julia --project=$GS_DIR -e 'using Pkg; Pkg.instantiate()'

--- a/source/julia/GrayScott.jl/scripts/config_summit.sh
+++ b/source/julia/GrayScott.jl/scripts/config_summit.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Replace these 3 entries
 PROJ_DIR=/gpfs/alpine/proj-shared/csc383
 export JULIA_DEPOT_PATH=$PROJ_DIR/etc/summit/julia_depot
 GS_DIR=$PROJ_DIR/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl

--- a/source/julia/GrayScott.jl/scripts/config_summit.sh
+++ b/source/julia/GrayScott.jl/scripts/config_summit.sh
@@ -8,6 +8,7 @@ GS_DIR=$PROJ_DIR/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl
 rm -f $GS_DIR/Manifest.toml
 rm -f $GS_DIR/LocalPreferences.toml
 
+# good practice to avoid conflicts with existing default modules 
 # needed to avoid seg fault with MPI
 module purge
 
@@ -18,21 +19,20 @@ module load cuda/11.0.3 # failure with 11.5.2
 module load adios2/2.8.1
 # module load julia/1.8.2 not working with CUDA.jl as it's missing libLLVM-13jl.so
 export PATH=$PROJ_DIR/opt/summit/julia-1.9.0-beta3/bin:$PATH
-#export LD_LIBRARY_PATH=$OLCF_JULIA_ROOT/lib/julia:$LD_LIBRARY_PATH
 
-# Required to point at underlying modules above
-export JULIA_CUDA_USE_BINARYBUILDER=false
 # Required to enable underlying ADIOS2 library from loaded module
 export JULIA_ADIOS2_PATH=$OLCF_ADIOS2_ROOT
 
-
-# Set up Julia packages pointing at the relative location of Project.toml
 # MPIPreferences to use spectrum-mpi
 julia --project=$GS_DIR -e 'using Pkg; Pkg.add("MPIPreferences")'
 julia --project=$GS_DIR -e 'using MPIPreferences; MPIPreferences.use_system_binary(; library_names=["libmpi_ibm"], mpiexec="jsrun")'
 
 # Instantiate the project by installing packages in Project.toml
 julia --project=$GS_DIR -e 'using Pkg; Pkg.instantiate()'
+
+# Adds to LocalPreferences.toml to use underlying system CUDA since CUDA.jl v4.0.0
+# https://cuda.juliagpu.org/stable/installation/overview/#Using-a-local-CUDA
+julia --project=$GS_DIR -e 'using CUDA; CUDA.set_runtime_version!("local")'
 
 # Adds a custom branch in case the development version is needed (for devs to test new features)
 julia --project=$GS_DIR -e 'using Pkg; Pkg.add(url="https://github.com/eschnett/ADIOS2.jl.git", rev="main")'

--- a/source/julia/GrayScott.jl/scripts/config_summit.sh
+++ b/source/julia/GrayScott.jl/scripts/config_summit.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+PROJ_DIR=/gpfs/alpine/proj-shared/csc383
+export JULIA_DEPOT_PATH=$PROJ_DIR/etc/summit/julia_depot
+GS_DIR=$PROJ_DIR/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl
+
+# remove existing generated Manifest.toml
+rm -f $GS_DIR/Manifest.toml
+rm -f $GS_DIR/LocalPreferences.toml
+
+# needed to avoid seg fault with MPI
+module purge
+
+# load required modules
+module load spectrum-mpi
+module load gcc/12.1.0 # needed by julia libraries
+module load cuda/11.0.3 # failure with 11.5.2
+module load adios2/2.8.1
+# module load julia/1.8.2 not working with CUDA.jl as it's missing libLLVM-13jl.so
+export PATH=$PROJ_DIR/opt/summit/julia-1.9.0-beta3/bin:$PATH
+#export LD_LIBRARY_PATH=$OLCF_JULIA_ROOT/lib/julia:$LD_LIBRARY_PATH
+
+# Required to point at underlying modules above
+export JULIA_CUDA_USE_BINARYBUILDER=false
+# Required to enable underlying ADIOS2 library from loaded module
+export JULIA_ADIOS2_PATH=$OLCF_ADIOS2_ROOT
+
+
+# Set up Julia packages pointing at the relative location of Project.toml
+# MPIPreferences to use spectrum-mpi
+julia --project=$GS_DIR -e 'using Pkg; Pkg.add("MPIPreferences")'
+julia --project=$GS_DIR -e 'using MPIPreferences; MPIPreferences.use_system_binary(; library_names=["libmpi_ibm"], mpiexec="jsrun")'
+
+# Instantiate the project by installing packages in Project.toml
+julia --project=$GS_DIR -e 'using Pkg; Pkg.instantiate()'
+
+# Adds a custom branch in case the development version is needed (for devs to test new features)
+julia --project=$GS_DIR -e 'using Pkg; Pkg.add(url="https://github.com/eschnett/ADIOS2.jl.git", rev="main")'
+
+# Build the new ADIOS2
+julia --project=$GS_DIR -e 'using Pkg; Pkg.build()'
+julia --project=$GS_DIR -e 'using Pkg; Pkg.precompile()'

--- a/source/julia/GrayScott.jl/scripts/job_crusher.sh
+++ b/source/julia/GrayScott.jl/scripts/job_crusher.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH -A CSC383_crusher
+#SBATCH -J gs-julia-1MPI-1GPU
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
+#SBATCH -t 0:02:00
+#SBATCH -p batch
+#SBATCH -N 1
+
+date
+
+GS_DIR=/gpfs/alpine/proj-shared/csc383/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl
+GS_EXE=$GS_DIR/gray-scott.jl
+
+srun -n 1 --gpus=1 julia --project=$GS_DIR $GS_EXE settings-files.json
+
+# launch this file with sbatch `$ sbatch job_crusher.sh`

--- a/source/julia/GrayScott.jl/scripts/job_summit.sh
+++ b/source/julia/GrayScott.jl/scripts/job_summit.sh
@@ -14,3 +14,5 @@ GS_DIR=/gpfs/alpine/proj-shared/csc383/wgodoy/ADIOS2-Examples/source/julia/GrayS
 GS_EXE=$GS_DIR/gray-scott.jl
 
 jsrun -n 1 -g 1 julia --project=$GS_DIR $GS_EXE settings-files.json
+
+# launch this file with bsub `$ bsub job_summit.sh`

--- a/source/julia/GrayScott.jl/scripts/job_summit.sh
+++ b/source/julia/GrayScott.jl/scripts/job_summit.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#    Begin LSF directives
+#BSUB -P csc383
+#BSUB -W 00:02
+#BSUB -nnodes 1
+#BSUB -J gs-julia
+#BSUB -o output.%J
+#BSUB -e output.%J 
+#BSUB -N godoywf@ornl.gov
+#    End BSUB directives and begin shell commands
+
+date
+GS_DIR=/gpfs/alpine/proj-shared/csc383/wgodoy/ADIOS2-Examples/source/julia/GrayScott.jl
+GS_EXE=$GS_DIR/gray-scott.jl
+
+jsrun -n 1 -g 1 julia --project=$GS_DIR $GS_EXE settings-files.json

--- a/source/julia/GrayScott.jl/src/GrayScott.jl
+++ b/source/julia/GrayScott.jl/src/GrayScott.jl
@@ -1,17 +1,32 @@
+"""
+GrayScott.jl is a Simulation and Analysis parallel framework for solving the 
+Gray-Scott 3D diffusion reaction system of equations of two variables U and V on 
+a regular Cartesian mesh.
+
+The bp output files can be visualized with ParaView.
+"""
 module GrayScott
 
-import MPI
+import MPI, ADIOS2
 
-include("simulation/Settings.jl")
+# contains relevant data containers "structs" for Input, Domain and Fields
+include(joinpath("simulation", "Structs.jl"))
 
-include("helper/Helper.jl")
+# contains helper functions for general use
+include(joinpath("helper", "Helper.jl"))
 import .Helper
 
-include("simulation/Inputs.jl")
+# initializes inputs from configuration file
+include(joinpath("simulation", "Inputs.jl"))
 import .Inputs
 
-include("simulation/Simulation.jl")
+# manages the simulation computation
+include(joinpath("simulation", "Simulation.jl"))
 import .Simulation
+
+# manages the I/O
+include(joinpath("simulation", "IO.jl"))
+import .IO
 
 function julia_main()::Cint
     try
@@ -23,16 +38,56 @@ function julia_main()::Cint
     return 0
 end
 
-function main(args::Vector{String})
-    @show args
-
-    # Initialize MPI and get world comm, rank, size
-    MPI.Init()
+function main(args::Vector{String})::Int32
     comm = MPI.COMM_WORLD
     rank = MPI.Comm_rank(comm)
     size = MPI.Comm_size(comm)
 
+    # a data struct that holds settings data from config_file in args
+    # example config file: ../examples/settings-files.json
     settings = Inputs.get_settings(args, comm)
+
+    # initialize MPI Cartesian Domain and Communicator
+    mpi_cart_domain = Simulation.init_domain(settings, comm)
+
+    # initialize fields
+    fields = Simulation.init_fields(settings,
+                                    mpi_cart_domain,
+                                    Helper.get_type(settings.precision))
+
+    # initialize IOStream struct holding ADIOS-2 components for parallel I/O
+    stream = IO.init(settings, mpi_cart_domain, fields)
+
+    restart_step::Int32 = 0
+    # @TODO: checkpoint-restart 
+    step::Int32 = restart_step
+
+    while step < settings.steps
+        Simulation.iterate!(fields, settings, mpi_cart_domain)
+        step += 1
+
+        if step % settings.plotgap == 0
+            if rank == 0
+                println("Simulation at step ", step, " writing output step ",
+                        step / settings.plotgap)
+            end
+
+            IO.write_step!(stream, step, fields)
+        end
+    end
+
+    IO.close!(stream)
+    return 0
+end
+
+function __init__()
+    # - Initialize here instead of main so that the MPI context can be available
+    # for tests.
+    # - Conditional allows for case when external users (or tests) have already
+    # initialized an MPI context.
+    if !MPI.Initialized()
+        MPI.Init()
+    end
 end
 
 end # module GrayScott

--- a/source/julia/GrayScott.jl/src/GrayScott.jl
+++ b/source/julia/GrayScott.jl/src/GrayScott.jl
@@ -39,6 +39,7 @@ function julia_main()::Cint
 end
 
 function main(args::Vector{String})::Int32
+    MPI.Init()
     comm = MPI.COMM_WORLD
     rank = MPI.Comm_rank(comm)
     size = MPI.Comm_size(comm)
@@ -77,17 +78,14 @@ function main(args::Vector{String})::Int32
     end
 
     IO.close!(stream)
-    return 0
-end
 
-function __init__()
-    # - Initialize here instead of main so that the MPI context can be available
-    # for tests.
-    # - Conditional allows for case when external users (or tests) have already
-    # initialized an MPI context.
-    if !MPI.Initialized()
-        MPI.Init()
+    # Debugging session or Julia REPL session, not needed overall as it would be 
+    # called when the program ends
+    if !isinteractive()
+        MPI.Finalize()
     end
+
+    return 0
 end
 
 end # module GrayScott

--- a/source/julia/GrayScott.jl/src/GrayScott.jl
+++ b/source/julia/GrayScott.jl/src/GrayScott.jl
@@ -1,0 +1,38 @@
+module GrayScott
+
+import MPI
+
+include("simulation/Settings.jl")
+
+include("helper/Helper.jl")
+import .Helper
+
+include("simulation/Inputs.jl")
+import .Inputs
+
+include("simulation/Simulation.jl")
+import .Simulation
+
+function julia_main()::Cint
+    try
+        main(ARGS)
+    catch
+        Base.invokelatest(Base.display_error, Base.catch_stack())
+        return 1
+    end
+    return 0
+end
+
+function main(args::Vector{String})
+    @show args
+
+    # Initialize MPI and get world comm, rank, size
+    MPI.Init()
+    comm = MPI.COMM_WORLD
+    rank = MPI.Comm_rank(comm)
+    size = MPI.Comm_size(comm)
+
+    settings = Inputs.get_settings(args, comm)
+end
+
+end # module GrayScott

--- a/source/julia/GrayScott.jl/src/analysis/pdfcalc.jl
+++ b/source/julia/GrayScott.jl/src/analysis/pdfcalc.jl
@@ -1,0 +1,160 @@
+
+import MPI
+import ArgParse
+import ADIOS2
+
+function _epsilon(d::T)::Bool where {T <: Number}
+    return (d < 1.0e-20)
+end
+
+"""
+Return 2 arrays pdf and bins of a 2D slice
+"""
+function _compute_pdf(data::Array{T, 3}, shape, count, nbins, min::T,
+                      max::T) where {T}
+    pdf = Array{T, 2}(undef, nbins, count)
+    bins = Array{T, 1}(undef, nbins)
+    bin_width = (max - min) / nbins
+
+    for i in 1:nbins
+        bins[i] = min + (i - 1) * bin_width
+    end
+
+    slice_size = shape[2] * shape[3]
+    # special case: only one bin or small window
+    if nbins == 1 || _epsilon(max - min) || _epsilon(bin_width)
+        fill!(pdf, slice_size)
+        return pdf, bins
+    end
+
+    # Calculate a PDF for 'nbins' bins for values between 'min' and 'max'
+
+    for c in 1:count
+        for j in 1:shape[2]
+            for k in 1:shape[3]
+                value = data[k, j, c]
+
+                if value > max || value < min
+                    @show value, " is outside [", min, max "]"
+                end
+                bin = floor((value - min) / bin_width)
+
+                if bin == nbins
+                    bin = nbins - 1
+                end
+                pdf[bin, c] += 1
+            end
+        end
+    end
+end
+
+function _parse_arguments(args)
+    s = ArgParse.ArgParseSettings(description = "gray-scott workflow pdf generator, Julia version")
+
+    #  @add_arg_table! s begin
+    #       "--opt1"               # an option (will take an argument)
+    #       "--opt2", "-o"         # another option, with short form
+    #       "arg1"                 # a positional argument
+    #   end
+
+    ArgParse.@add_arg_table! s begin
+        "input"
+        help = "Name of the input file handle for reading data"
+        arg_type = String
+        required = true
+        "output"
+        help = "Name of the output file to which data must be written"
+        arg_type = String
+        required = true
+        "N"
+        help = "Number of bins for the PDF calculation, default = 1000"
+        arg_type = Int64
+        required = false
+        default = 1000
+        "output_inputdata"
+        help = "YES will write the original variables besides the analysis results"
+        arg_type = Bool
+        required = false
+        default = false
+    end
+
+    # parse_args return a dictionary with key/value for arguments
+    parsed_arguments = ArgParse.parse_args(args, s)
+    return parsed_arguments
+end
+
+function _read_data_write_pdf(inputs, comm)
+    in_filename = inputs["input"]
+    out_filename = inputs["output"]
+    nbins = inputs["N"]
+    write_inputvars = inputs["output_inputdata"]
+
+    adios = ADIOS2.adios_init_mpi("adios2.xml", comm)
+
+    reader_io = ADIOS2.declare_io(adios, "SimulationOutput")
+    writer_io = ADIOS2.declare_io(adios, "PDFAnalysisOutput")
+
+    rank = MPI.Comm_rank(comm)
+    size = MPI.Comm_size(comm)
+
+    if rank == 0
+        println("PDF analysis reads from Simulation using engine type:  ",
+                ADIOS2.engine_type(reader_io))
+        println("PDF analysis writes using engine type:  ",
+                ADIOS2.engine_type(writer_io))
+    end
+
+    # Engines for reading and writing
+    reader = ADIOS2.open(reader_io, inputs["input"], ADIOS2.mode_read)
+    writer = ADIOS2.open(writer_io, inputs["output"], ADIOS2.mode_write)
+
+    # break inside if needed
+    while true
+
+        # timeout is 10 seconds
+        read_status = ADIOS2.begin_step(reader, ADIOS2.step_mode_read, 10)
+
+        if read_status == ADIOS2.step_status_not_ready
+            # sleep in seconds, minimum is one milisecond = 0.001
+            sleep(1)
+            continue
+        else if read_status != ADIOS2.step_status_ok
+            break
+        end
+
+        step_sim_out = ADIOS2.current_step(reader)
+        var_U = ADIOS2.inquire_variable(reader_io, "U")
+        var_V = ADIOS2.inquire_variable(reader_io, "V")
+        var_step = ADIOS2.inquire_variable(reader_io, "step")
+
+        shape = ADIOS2.shape(var_U)
+
+        # Split in the slowest dimension
+        count_z = shape[3] / size
+        start_z = count_z * rank
+
+        # Last process needs to read all the rest
+        if rank == size-1
+            count_z = shape[3] - count_z * (size-1)
+        end
+
+        # missing set_selection
+        start = ( 0,0,start_z)
+        count = (shape[1], shape[2], count_z)
+        ADIOS2.set_selection(var_U, start, count)
+        ADIOS2.set_selection(var_V, start, count)
+
+        # Calculate
+
+    end
+end
+
+function main(args)
+    MPI.Init()
+
+    inputs = _parse_arguments(args)
+    comm = MPI.COMM_WORLD
+    _read_data_write_pdf(inputs, comm)
+
+    MPI.Finalize()
+end

--- a/source/julia/GrayScott.jl/src/helper/Helper.jl
+++ b/source/julia/GrayScott.jl/src/helper/Helper.jl
@@ -1,7 +1,6 @@
 
 module Helper
 
-export bcase_file
 include("helperMPI.jl")
 
 end

--- a/source/julia/GrayScott.jl/src/helper/Helper.jl
+++ b/source/julia/GrayScott.jl/src/helper/Helper.jl
@@ -1,0 +1,7 @@
+
+module Helper
+
+export bcase_file
+include("helperMPI.jl")
+
+end

--- a/source/julia/GrayScott.jl/src/helper/Helper.jl
+++ b/source/julia/GrayScott.jl/src/helper/Helper.jl
@@ -2,5 +2,6 @@
 module Helper
 
 include("helperMPI.jl")
+include("helperString.jl")
 
 end

--- a/source/julia/GrayScott.jl/src/helper/helperMPI.jl
+++ b/source/julia/GrayScott.jl/src/helper/helperMPI.jl
@@ -1,16 +1,15 @@
 
 import MPI
 
-function bcast_file(file_name::String, comm)
-    rank = MPI.Comm_rank(comm)
-    if rank == 0
-        io = open(file_name, "r")
-        @show typeof(io)
-        data = read(io)
-        @show length(data)
-        # buffer::Vector{Int8}
-        # read!(io, buffer)
-        #println(io)
-    else
+export bcase_file
+
+function bcast_file_contents(file_name::String, comm, root = 0)::String
+    size::UInt32 = 0
+    data::Vector{UInt8} = []
+    if MPI.Comm_rank(comm) == root
+        data = read(open(file_name, "r"))
     end
+
+    data = MPI.bcast(data, comm)
+    return String(data)
 end

--- a/source/julia/GrayScott.jl/src/helper/helperMPI.jl
+++ b/source/julia/GrayScott.jl/src/helper/helperMPI.jl
@@ -1,0 +1,16 @@
+
+import MPI
+
+function bcast_file(file_name::String, comm)
+    rank = MPI.Comm_rank(comm)
+    if rank == 0
+        io = open(file_name, "r")
+        @show typeof(io)
+        data = read(io)
+        @show length(data)
+        # buffer::Vector{Int8}
+        # read!(io, buffer)
+        #println(io)
+    else
+    end
+end

--- a/source/julia/GrayScott.jl/src/helper/helperString.jl
+++ b/source/julia/GrayScott.jl/src/helper/helperString.jl
@@ -1,0 +1,14 @@
+
+export get_type
+
+function get_type(input::String)
+    if input == "Float64"
+        return Float64
+    elseif input == "Float32"
+        return Float32
+    elseif input == "Float16"
+        return Float16
+    end
+
+    return nothing
+end

--- a/source/julia/GrayScott.jl/src/simulation/IO.jl
+++ b/source/julia/GrayScott.jl/src/simulation/IO.jl
@@ -1,0 +1,106 @@
+module IO
+
+export init, write_step!
+
+# import external module
+import ADIOS2
+
+# internal submodule
+import ..Simulation
+# types from parent module types in Structs.jl
+import ..Settings, ..MPICartDomain, ..Fields, ..IOStream
+
+function init(settings::Settings, mcd::MPICartDomain,
+              fields::Fields{T}) where {T}
+
+    # initialize adios MPI using the cartesian communicator
+    adios = ADIOS2.adios_init_mpi(mcd.cart_comm)
+    io = ADIOS2.declare_io(adios, "SimulationOutput")
+    # @TODO: implement ADIOS2.set_engine in ADIOS2.jl
+    engine = ADIOS2.open(io, settings.output, ADIOS2.mode_write)
+
+    # store simulation run provenance as attributes
+    ADIOS2.define_attribute(io, "F", settings.F)
+    ADIOS2.define_attribute(io, "k", settings.k)
+    ADIOS2.define_attribute(io, "dt", settings.dt)
+    ADIOS2.define_attribute(io, "Du", settings.Du)
+    ADIOS2.define_attribute(io, "Dv", settings.Dv)
+    ADIOS2.define_attribute(io, "noise", settings.noise)
+
+    _add_visualization_schemas(io, settings.L)
+
+    # ADIOS2 requires tuples for the dimensions
+    # define global variables u and v
+    shape = (settings.L, settings.L, settings.L)
+    start = Tuple(mcd.proc_offsets)
+    count = Tuple(mcd.proc_sizes)
+
+    var_step = ADIOS2.define_variable(io, "step", Int32)
+    var_U = ADIOS2.define_variable(io, "U", T, shape, start, count)
+    var_V = ADIOS2.define_variable(io, "V", T, shape, start, count)
+
+    return IOStream(adios, io, engine, var_step, var_U, var_V)
+end
+
+function write_step!(stream::IOStream, step::Int32, fields::Fields{T}) where {T}
+
+    # this creates temporaries similar to Fortran
+    u_no_ghost, v_no_ghost = Simulation.get_fields(fields)
+
+    # writer engine
+    w = stream.engine
+
+    ADIOS2.begin_step(w)
+    ADIOS2.put!(w, stream.var_step, step)
+    ADIOS2.put!(w, stream.var_U, u_no_ghost)
+    ADIOS2.put!(w, stream.var_V, v_no_ghost)
+    ADIOS2.end_step(w)
+end
+
+function close!(stream::IOStream)
+    ADIOS2.close(stream.engine)
+    ADIOS2.adios_finalize(stream.adios)
+end
+
+function _add_visualization_schemas(io, length)
+
+    # Fides schema
+    ADIOS2.define_attribute(io, "Fides_Data_Model", "uniform")
+    ADIOS2.define_attribute_array(io, "Fides_Origin", [0.0, 0.0, 0.0])
+    ADIOS2.define_attribute_array(io, "Fides_Spacing", [0.1, 0.1, 0.1])
+    ADIOS2.define_attribute(io, "Fides_Dimension_Variable", "U")
+    ADIOS2.define_attribute_array(io, "Fides_Variable_List", ["U", "V"])
+    ADIOS2.define_attribute_array(io, "Fides_Variable_Associations",
+                                  ["points", "points"])
+
+    # VTX schema
+    # string concatenation uses *, ^ is for repetition 
+    # if length = 64
+    # extent = "0 64 0 64 0 64 "
+    extent = ("0 " * string(length) * " ")^3
+    extent = rstrip(extent)
+
+    # deactive code formatting using JuliaFormatter.jl 
+    # raw strings: " must be escaped with \"
+    #! format: off
+    vtx_schema = raw"
+        <?xml version=\"1.0\"?>
+        <VTKFile type=\"ImageData\" version=\"0.1\" byte_order=\"LittleEndian\">
+          <ImageData WholeExtent=\"" * extent * raw"\" Origin=\"0 0 0\" Spacing=\"1 1 1\">
+            <Piece Extent=\"" * extent * raw"\">
+              <CellData Scalars=\"U\">
+                <DataArray Name=\"U\" />
+                <DataArray Name=\"V\" />
+                <DataArray Name=\"TIME\">
+                  step
+                </DataArray>
+              </CellData>
+            </Piece>
+          </ImageData>
+        </VTKFile>"
+    #! format: on
+    # reactive code formatting using JuliaFormatter.jl
+    ADIOS2.define_attribute(io, "vtk.xml", vtx_schema)
+end
+
+end

--- a/source/julia/GrayScott.jl/src/simulation/Inputs.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Inputs.jl
@@ -1,0 +1,51 @@
+
+# submodule used by GrayScott to handle inputs 
+module Inputs
+
+export get_settings
+
+import ArgParse
+
+# public facing function
+function get_settings(args::Vector{String}, comm)
+    config_file = _parse_args(args)
+
+    if endWith(config_file, ".json")
+        return _parse_settings_json(config_file, comm)
+    end
+
+    return
+end
+
+# local scope functions
+function _parse_settings_json(config_file::String, comm)
+end
+
+function _parse_args(args::Vector{String};
+                     error_handler = ArgParse.default_handler)::String
+    s = ArgParse.ArgParseSettings(description = "gray-scott workflow simulation example configuration file, Julia version, GrayScott.jl",
+                                  exc_handler = error_handler)
+
+    ArgParse.@add_arg_table! s begin
+        "config_file"
+        help = "configuration file"
+        arg_type = String
+        required = true
+    end
+
+    # parse_args return a dictionary with key/value for arguments
+    parsed_arguments = ArgParse.parse_args(args, s)
+
+    # key is mandatory, so it's safe to retrieve
+    config_file::String = parsed_arguments["config_file"]
+
+    # check format extension
+    if !endswith(config_file, ".json") &&
+       !(endswith(config_file, ".yaml") || endswith(config_file, ".yml"))
+        throw(ArgumentError("config file must be json, yaml format. Extension not recognized.\n"))
+    end
+
+    return config_file
+end
+
+end # module

--- a/source/julia/GrayScott.jl/src/simulation/Settings.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Settings.jl
@@ -24,7 +24,29 @@ Base.@kwdef mutable struct Settings
     restart::Bool = false
     restart_input::String = "ckpt.bp"
     adios_config::String = "adios2.yaml"
-    adios_span::String = false
+    adios_span::Bool = false
     adios_memory_selection::Bool = false
     mesh_type::String = "image"
 end
+
+SettingsKeys = Set{String}([
+                               "L",
+                               "steps",
+                               "plotgap",
+                               "F",
+                               "k",
+                               "dt",
+                               "Du",
+                               "Dv",
+                               "noise",
+                               "output",
+                               "checkpoint",
+                               "checkpoint_freq",
+                               "checkpoint_output",
+                               "restart",
+                               "restart_input",
+                               "adios_config",
+                               "adios_span",
+                               "adios_memory_selection",
+                               "mesh_type",
+                           ])

--- a/source/julia/GrayScott.jl/src/simulation/Settings.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Settings.jl
@@ -1,0 +1,30 @@
+
+"""
+Settings carry the settings from the simulation config file (json or yaml formats)
+
+Using Base.@kwdef macro for easy defaults and enable keyword arguments
+Settings(Du = 0.2, noise = 0.2) 
+See:
+https://discourse.julialang.org/t/default-value-of-some-fields-in-a-mutable-struct/33408/24?u=williamfgc
+"""
+Base.@kwdef mutable struct Settings
+    L::Int64 = 128
+    steps::Int32 = 20000
+    plotgap::Int32 = 200
+    F::Float64 = 0.04
+    k::Float64 = 0
+    dt::Float64 = 0.2
+    Du::Float64 = 0.05
+    Dv::Float64 = 0.1
+    noise::Float64 = 0.0
+    output::String = "foo.bp"
+    checkpoint::Bool = false
+    checkpoint_freq::Int32 = 2000
+    checkpoint_output::String = "ckpt.bp"
+    restart::Bool = false
+    restart_input::String = "ckpt.bp"
+    adios_config::String = "adios2.yaml"
+    adios_span::String = false
+    adios_memory_selection::Bool = false
+    mesh_type::String = "image"
+end

--- a/source/julia/GrayScott.jl/src/simulation/Simulation.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Simulation.jl
@@ -1,4 +1,261 @@
 
 module Simulation
 
+export init_domain, init_fields
+
+import MPI
+import Distributions
+
+# from parent module
+import ..Settings, ..MPICartDomain, ..Fields
+
+# functions for NVIDIA GPUs using CUDA.jl
+include("Simulation_CUDA.jl")
+
+function init_domain(settings::Settings, comm::MPI.Comm)::MPICartDomain
+    mcd = MPICartDomain()
+
+    # set dims and Cartesian communicator
+    mcd.dims = MPI.Dims_create(MPI.Comm_size(comm), mcd.dims)
+    mcd.cart_comm = MPI.Cart_create(comm, mcd.dims)
+
+    # set proc local coordinates in Cartesian communicator
+    rank = MPI.Comm_rank(comm)
+    mcd.coords = MPI.Cart_coords(mcd.cart_comm, rank)
+
+    # set proc local mesh sizes
+    mcd.proc_sizes = settings.L ./ mcd.dims
+
+    for (i, coord) in enumerate(mcd.coords)
+        if coord < settings.L % mcd.dims[i]
+            mcd.proc_sizes[i] += 1
+        end
+    end
+
+    # set proc local offsets
+    for i in 1:3
+        mcd.proc_offsets[i] = settings.L / mcd.dims[i] *
+                              mcd.coords[i]
+        +min(settings.L % mcd.dims[i], mcd.coords[i])
+    end
+
+    # get neighbors ranks
+    mcd.proc_neighbors["west"],
+    mcd.proc_neighbors["east"] = MPI.Cart_shift(mcd.cart_comm, 0, 1)
+    mcd.proc_neighbors["down"],
+    mcd.proc_neighbors["up"] = MPI.Cart_shift(mcd.cart_comm, 1, 1)
+    mcd.proc_neighbors["south"],
+    mcd.proc_neighbors["north"] = MPI.Cart_shift(mcd.cart_comm, 2, 1)
+
+    return mcd
 end
+
+function init_fields(settings::Settings,
+                     mcd::MPICartDomain, T)::Fields{T}
+    lowercase_backend = lowercase(settings.backend)
+    if lowercase_backend == "cuda"
+        return _init_fields_cuda(settings, mcd, T)
+    elseif lowercase_backend == "amdgpu"
+    end
+
+    return _init_fields_cpu(settings, mcd, T)
+end
+
+function _init_fields_cpu(settings::Settings,
+                          mcd::MPICartDomain, T)::Fields{T}
+    size_x = mcd.proc_sizes[1]
+    size_y = mcd.proc_sizes[2]
+    size_z = mcd.proc_sizes[3]
+
+    # should be ones
+    u = ones(T, size_x + 2, size_y + 2, size_z + 2)
+    v = zeros(T, size_x + 2, size_y + 2, size_z + 2)
+
+    u_temp = zeros(T, size_x + 2, size_y + 2, size_z + 2)
+    v_temp = zeros(T, size_x + 2, size_y + 2, size_z + 2)
+
+    function is_inside(x, y, z, offsets, sizes)::Bool
+        if x < offsets[1] || x >= offsets[1] + sizes[1]
+            return false
+        end
+        if y < offsets[2] || y >= offsets[2] + sizes[2]
+            return false
+        end
+        if z < offsets[3] || z >= offsets[3] + sizes[3]
+            return false
+        end
+
+        return true
+    end
+
+    d::Int64 = 6
+
+    # global locations
+    minL = Int64(settings.L / 2 - d)
+    maxL = Int64(settings.L / 2 + d)
+
+    xoff = mcd.proc_offsets[1]
+    yoff = mcd.proc_offsets[2]
+    zoff = mcd.proc_offsets[3]
+
+    Threads.@threads for z in minL:maxL
+        for y in minL:maxL
+            for x in minL:maxL
+                if !is_inside(x, y, z, mcd.proc_offsets, mcd.proc_sizes)
+                    continue
+                end
+
+                # Julia is 1-index, like Fortran :)
+                u[x - xoff + 2, y - yoff + 2, z - zoff + 2] = 0.25
+                v[x - xoff + 2, y - yoff + 2, z - zoff + 2] = 0.33
+            end
+        end
+    end
+
+    xy_face_t, xz_face_t, yz_face_t = _get_mpi_faces(size_x, size_y, size_z, T)
+
+    fields = Fields(u, v, u_temp, v_temp, xy_face_t, xz_face_t, yz_face_t)
+    return fields
+end
+
+function iterate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
+                  mcd::MPICartDomain) where {T, N}
+    _exchange!(fields, mcd)
+    # this function is the bottleneck
+    _calculate!(fields, settings, mcd)
+
+    # swap the names
+    fields.u, fields.u_temp = fields.u_temp, fields.u
+    fields.v, fields.v_temp = fields.v_temp, fields.v
+end
+
+function _get_mpi_faces(size_x, size_y, size_z, T)
+
+    ## create a new type taking: count, block length, stride
+    ## to interoperate with MPI for ghost cell exchange
+    xy_face_t = MPI.Types.create_vector(size_y + 2, size_x, size_x + 2,
+                                        MPI.Datatype(T))
+    xz_face_t = MPI.Types.create_vector(size_z, size_x,
+                                        (size_x + 2) * (size_y + 2),
+                                        MPI.Datatype(T))
+    yz_face_t = MPI.Types.create_vector((size_y + 2) * (size_z + 2), 1,
+                                        size_x + 2, MPI.Datatype(T))
+    MPI.Types.commit!(xy_face_t)
+    MPI.Types.commit!(xz_face_t)
+    MPI.Types.commit!(yz_face_t)
+
+    return xy_face_t, xz_face_t, yz_face_t
+end
+
+function _exchange!(fields, mcd)
+    """
+    Send XY face z=size_z+1 to north and receive z=1 from south
+    """
+    function _exchange_xy!(var, size_z, data_type, rank1, rank2, comm)
+        # to north
+        send_buf = MPI.Buffer(@view(var[2, 1, size_z + 1]), 1, data_type)
+        recv_buf = MPI.Buffer(@view(var[2, 1, 1]), 1, data_type)
+        MPI.Sendrecv!(send_buf, recv_buf, comm, dest = rank1, source = rank2)
+
+        # to south
+        send_buf = MPI.Buffer(@view(var[2, 1, 2]), 1, data_type)
+        recv_buf = MPI.Buffer(@view(var[2, 1, size_z + 2]), 1, data_type)
+        MPI.Sendrecv!(send_buf, recv_buf, comm, dest = rank2, source = rank1)
+    end
+
+    """
+    Send XZ face y=size_y+1 to up and receive y=1 from down
+    """
+    function _exchange_xz!(var, size_y, data_type, rank1, rank2, comm)
+        # to up
+        send_buf = MPI.Buffer(@view(var[2, size_y + 1, 2]), 1, data_type)
+        recv_buf = MPI.Buffer(@view(var[2, 1, 2]), 1, data_type)
+        MPI.Sendrecv!(send_buf, recv_buf, comm, dest = rank1, source = rank2)
+
+        # to down
+        send_buf = MPI.Buffer(@view(var[2, 2, 2]), 1, data_type)
+        recv_buf = MPI.Buffer(@view(var[2, size_y + 2, 2]), 1, data_type)
+        MPI.Sendrecv!(send_buf, recv_buf, comm, dest = rank2, source = rank1)
+    end
+
+    """
+    Send YZ face x=size_x+2 to east and receive x=2 from west
+    """
+    function _exchange_yz!(var, size_x, data_type, rank1, rank2, comm)
+        # to east
+        send_buf = MPI.Buffer(@view(var[size_x + 1, 1, 1]), 1, data_type)
+        recv_buf = MPI.Buffer(@view(var[1, 1, 1]), 1, data_type)
+        MPI.Sendrecv!(send_buf, recv_buf, comm, dest = rank1, source = rank2)
+
+        # to west
+        send_buf = MPI.Buffer(@view(var[2, 1, 1]), 1, data_type)
+        recv_buf = MPI.Buffer(@view(var[size_x + 2, 1, 1]), 1, data_type)
+        MPI.Sendrecv!(send_buf, recv_buf, comm, dest = rank2, source = rank1)
+    end
+
+    for var in [fields.u, fields.v]
+        _exchange_xy!(var, mcd.proc_sizes[3], fields.xy_face_t,
+                      mcd.proc_neighbors["north"], mcd.proc_neighbors["south"],
+                      mcd.cart_comm)
+
+        _exchange_xz!(var, mcd.proc_sizes[2], fields.xz_face_t,
+                      mcd.proc_neighbors["up"], mcd.proc_neighbors["down"],
+                      mcd.cart_comm)
+
+        _exchange_yz!(var, mcd.proc_sizes[1], fields.yz_face_t,
+                      mcd.proc_neighbors["east"], mcd.proc_neighbors["west"],
+                      mcd.cart_comm)
+    end
+end
+
+function _calculate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
+                     mcd::MPICartDomain) where {T, N}
+    Du = convert(T, settings.Du)
+    Dv = convert(T, settings.Dv)
+    F = convert(T, settings.F)
+    K = convert(T, settings.k)
+    noise = convert(T, settings.noise)
+    dt = convert(T, settings.dt)
+
+    # loop through non-ghost cells, bounds are inclusive
+    Threads.@threads for k in 2:(mcd.proc_sizes[3] + 1)
+        for j in 2:(mcd.proc_sizes[2] + 1)
+            for i in 2:(mcd.proc_sizes[1] + 1)
+                u = fields.u[i, j, k]
+                v = fields.v[i, j, k]
+
+                # introduce a random disturbance on du
+                du = Du * _laplacian(i, j, k, fields.u) - u * v^2 +
+                     F * (1.0 - u) +
+                     noise * rand(Distributions.Uniform(-1, 1))
+
+                dv = Dv * _laplacian(i, j, k, fields.v) + u * v^2 -
+                     (F + K) * v
+
+                # advance the next step
+                fields.u_temp[i, j, k] = u + du * dt
+                fields.v_temp[i, j, k] = v + dv * dt
+            end
+        end
+    end
+end
+
+"""
+   7-point stencil around the cell
+"""
+function _laplacian(i, j, k, var)
+    l = var[i - 1, j, k] + var[i + 1, j, k] + var[i, j - 1, k] +
+        var[i, j + 1, k] + var[i, j, k - 1] + var[i, j, k + 1] -
+        6.0 * var[i, j, k]
+    return l / 6.0
+end
+
+function get_fields(fields::Fields{T, N, Array{T, N}}) where {T, N}
+    u_no_ghost = fields.u[(begin + 1):(end - 1), (begin + 1):(end - 1),
+                          (begin + 1):(end - 1)]
+    v_no_ghost = fields.v[(begin + 1):(end - 1), (begin + 1):(end - 1),
+                          (begin + 1):(end - 1)]
+    return u_no_ghost, v_no_ghost
+end
+
+end # module 

--- a/source/julia/GrayScott.jl/src/simulation/Simulation.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Simulation.jl
@@ -1,0 +1,4 @@
+
+module Simulation
+
+end

--- a/source/julia/GrayScott.jl/src/simulation/Simulation_AMDGPU.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Simulation_AMDGPU.jl
@@ -141,8 +141,10 @@ function _calculte_kernel_amdgpu!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
             v_ijk = v[i, j, k]
 
             du = Du * _laplacian(i, j, k, u) - u_ijk * v_ijk^2 +
-                 F * (1.0 - u_ijk) +
-                 noise * rand(Distributions.Uniform(-1, 1))
+                 F * (1.0 - u_ijk)
+            # + noise * AMDGPU.rand(eltype(u))
+            # WIP in AMDGPU.jl, works with CUDA.jl
+            # + rand(Distributions.Uniform(-1, 1))
 
             dv = Dv * _laplacian(i, j, k, v) + u_ijk * v_ijk^2 -
                  (F + K) * v_ijk

--- a/source/julia/GrayScott.jl/src/simulation/Simulation_CUDA.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Simulation_CUDA.jl
@@ -1,0 +1,164 @@
+
+import CUDA
+
+function _init_fields_cuda(settings::Settings, mcd::MPICartDomain,
+                           T)::Fields{T, 3,
+                                      CUDA.CuArray{T, 3, CUDA.Mem.DeviceBuffer}}
+    size_x = mcd.proc_sizes[1]
+    size_y = mcd.proc_sizes[2]
+    size_z = mcd.proc_sizes[3]
+
+    # should be ones
+    u = CUDA.ones(T, size_x + 2, size_y + 2, size_z + 2)
+    v = CUDA.zeros(T, size_x + 2, size_y + 2, size_z + 2)
+
+    u_temp = CUDA.zeros(T, size_x + 2, size_y + 2, size_z + 2)
+    v_temp = CUDA.zeros(T, size_x + 2, size_y + 2, size_z + 2)
+
+    cu_offsets = CUDA.CuArray(mcd.proc_offsets)
+    cu_sizes = CUDA.CuArray(mcd.proc_sizes)
+
+    d::Int64 = 6
+    minL = Int64(settings.L / 2 - d)
+    maxL = Int64(settings.L / 2 + d)
+
+    # @TODO: get ideal blocks and threads
+    threads = (16, 16)
+    blocks = (settings.L, settings.L)
+
+    CUDA.@cuda threads=threads blocks=blocks _populate!(u, v,
+                                                        cu_offsets,
+                                                        cu_sizes,
+                                                        minL, maxL)
+
+    xy_face_t, xz_face_t, yz_face_t = _get_mpi_faces(size_x, size_y, size_z, T)
+
+    fields = Fields(u, v, u_temp, v_temp, xy_face_t, xz_face_t, yz_face_t)
+    return fields
+end
+
+function iterate!(fields::Fields{T, N, CUDA.CuArray{T, N, CUDA.Mem.DeviceBuffer
+                                                    }}, settings::Settings,
+                  mcd::MPICartDomain) where {T, N}
+    _exchange!(fields, mcd)
+    # this function is the bottleneck
+    _calculate!(fields, settings, mcd)
+
+    # swap the names
+    fields.u, fields.u_temp = fields.u_temp, fields.u
+    fields.v, fields.v_temp = fields.v_temp, fields.v
+end
+
+function _populate!(u, v, offsets, sizes, minL, maxL)
+    function is_inside(x, y, z, offsets, sizes)::Bool
+        if x < offsets[1] || x >= offsets[1] + sizes[1]
+            return false
+        end
+        if y < offsets[2] || y >= offsets[2] + sizes[2]
+            return false
+        end
+        if z < offsets[3] || z >= offsets[3] + sizes[3]
+            return false
+        end
+
+        return true
+    end
+
+    # local coordinates (this are 1-index already)
+    lz = (CUDA.blockIdx().x - Int32(1)) * CUDA.blockDim().x +
+         CUDA.threadIdx().x
+    ly = (CUDA.blockIdx().y - Int32(1)) * CUDA.blockDim().y +
+         CUDA.threadIdx().y
+
+    if lz <= size(u, 3) && ly <= size(u, 2)
+
+        # get global coordinates
+        z = lz + offsets[3] - 1
+        y = ly + offsets[2] - 1
+
+        if z >= minL && z <= maxL && y >= minL && y <= maxL
+            xoff = offsets[1]
+
+            for x in minL:maxL
+                # check if global coordinates for initialization are inside the region
+                if !is_inside(x, y, z, offsets, sizes)
+                    continue
+                end
+
+                # Julia is 1-index, like Fortran :)
+                u[x - xoff + 2, ly + 1, lz + 1] = 0.25
+                v[x - xoff + 2, ly + 1, lz + 1] = 0.33
+            end
+        end
+    end
+end
+
+function _calculate!(fields::Fields{T, N,
+                                    CUDA.CuArray{T, N, CUDA.Mem.DeviceBuffer}},
+                     settings::Settings,
+                     mcd::MPICartDomain) where {T, N}
+    function _calculte_kernel!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
+                               noise, dt)
+
+        # local coordinates (this are 1-index already)
+        k = (CUDA.blockIdx().x - Int32(1)) * CUDA.blockDim().x +
+            CUDA.threadIdx().x
+        j = (CUDA.blockIdx().y - Int32(1)) * CUDA.blockDim().y +
+            CUDA.threadIdx().y
+
+        # loop through non-ghost cells
+        if k >= 2 && k <= sizes[3] + 1 && j >= 2 && j <= sizes[2] + 1
+            # bounds are inclusive
+            for i in 2:(sizes[1] + 1)
+                u_ijk = u[i, j, k]
+                v_ijk = v[i, j, k]
+
+                du = Du * _laplacian(i, j, k, u) - u_ijk * v_ijk^2 +
+                     F * (1.0 - u_ijk) +
+                     noise * rand(Distributions.Uniform(-1, 1))
+
+                dv = Dv * _laplacian(i, j, k, v) + u_ijk * v_ijk^2 -
+                     (F + K) * v_ijk
+
+                # advance the next step
+                u_temp[i, j, k] = u_ijk + du * dt
+                v_temp[i, j, k] = v_ijk + dv * dt
+            end
+        end
+    end
+
+    Du = convert(T, settings.Du)
+    Dv = convert(T, settings.Dv)
+    F = convert(T, settings.F)
+    K = convert(T, settings.k)
+    noise = convert(T, settings.noise)
+    dt = convert(T, settings.dt)
+
+    cu_sizes = CUDA.CuArray(mcd.proc_sizes)
+
+    threads = (16, 16)
+    blocks = (settings.L, settings.L)
+
+    CUDA.@cuda threads=threads blocks=blocks _calculte_kernel!(fields.u,
+                                                               fields.v,
+                                                               fields.u_temp,
+                                                               fields.v_temp,
+                                                               cu_sizes,
+                                                               Du, Dv, F, K,
+                                                               noise, dt)
+end
+
+function get_fields(fields::Fields{T, N,
+                                   CUDA.CuArray{T, N, CUDA.Mem.DeviceBuffer}}) where {
+                                                                                      T,
+                                                                                      N
+                                                                                      }
+    u = Array(fields.u)
+    u_no_ghost = u[(begin + 1):(end - 1), (begin + 1):(end - 1),
+                   (begin + 1):(end - 1)]
+
+    v = Array(fields.v)
+    v_no_ghost = v[(begin + 1):(end - 1), (begin + 1):(end - 1),
+                   (begin + 1):(end - 1)]
+    return u_no_ghost, v_no_ghost
+end

--- a/source/julia/GrayScott.jl/src/simulation/Structs.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Structs.jl
@@ -76,7 +76,7 @@ end
 
 """
 Carry the physical field outputs: u and v
-@TODO: must implement for GPU arrays
+Using AbstractArray to allow for Array, CuArray and ROCArray
 """
 mutable struct Fields{T, N, A <: AbstractArray{T, N}}
     u::A
@@ -89,6 +89,9 @@ mutable struct Fields{T, N, A <: AbstractArray{T, N}}
     yz_face_t::MPI.Datatype
 end
 
+"""
+Carry the I/O information for outputs
+"""
 struct IOStream
     adios::ADIOS2.Adios
     io::ADIOS2.AIO

--- a/source/julia/GrayScott.jl/test/Project.toml
+++ b/source/julia/GrayScott.jl/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/source/julia/GrayScott.jl/test/functional/functional-GrayScott.jl
+++ b/source/julia/GrayScott.jl/test/functional/functional-GrayScott.jl
@@ -1,0 +1,12 @@
+
+import GrayScott
+import Test: @testset, @test
+
+@testset "GrayScott" begin MPI.mpiexec() do runcmd
+    config_file = joinpath(dirname(Base.active_project()), "examples",
+                           "settings-files.json")
+
+    juliacmd = `julia --project gray-scott.jl $config_file`
+
+    @test run(`mpirun -n 4 $juliacmd`).exitcode == 0
+end end

--- a/source/julia/GrayScott.jl/test/runtests.jl
+++ b/source/julia/GrayScott.jl/test/runtests.jl
@@ -1,16 +1,26 @@
 
 import MPI
 
-# Run all lightweight unit and functional tests within a single MPI session
+# Run all lightweight unit tests within a single MPI session
 MPI.Init()
 
-# unit tests
+verbose = false
+
+# unit tests for module GrayScott 
 include(joinpath("unit", "helper", "unit-helperMPI.jl"))
 
-# functional tests
 include(joinpath("unit", "simulation", "unit-Inputs.jl"))
+include(joinpath("unit", "simulation", "unit-Simulation.jl"))
+include(joinpath("unit", "simulation", "unit-Simulation_CUDA.jl"))
+include(joinpath("unit", "simulation", "unit-IO.jl"))
+
+# unit tests for analysis scripts
+include(joinpath("unit", "analysis", "unit-pdfcalc.jl"))
 
 MPI.Finalize()
 
 # Command line tests. These are heavier tests launched as separate processes.
 # The downside is that only global success can be tested and not internal states.
+
+# functional tests
+# include(joinpath("functional", "functional-GrayScott.jl"))

--- a/source/julia/GrayScott.jl/test/runtests.jl
+++ b/source/julia/GrayScott.jl/test/runtests.jl
@@ -1,0 +1,16 @@
+
+import MPI
+
+# Run all lightweight unit and functional tests within a single MPI session
+MPI.Init()
+
+# unit tests
+include(joinpath("unit", "helper", "unit-helperMPI.jl"))
+
+# functional tests
+include(joinpath("unit", "simulation", "unit-Inputs.jl"))
+
+MPI.Finalize()
+
+# Command line tests. These are heavier tests launched as separate processes.
+# The downside is that only global success can be tested and not internal states.

--- a/source/julia/GrayScott.jl/test/unit/analysis/unit-pdfcalc.jl
+++ b/source/julia/GrayScott.jl/test/unit/analysis/unit-pdfcalc.jl
@@ -1,0 +1,19 @@
+
+import Test: @testset, @test, @test_throws
+
+include(joinpath(dirname(Base.active_project()), "src", "analysis",
+                 "pdfcalc.jl"))
+
+@testset "unit-analysis.pdfcalc._parse_args" begin
+    inputs = _parse_arguments(["foo.bp", "bar.bp", "1500"])
+    @test inputs["input"] == "foo.bp"
+    @test inputs["output"] == "bar.bp"
+    @test inputs["N"] == 1500
+    @test inputs["output_inputdata"] == false
+
+    inputs = _parse_arguments(["input.bp", "output.bp", "1000", "true"])
+    @test inputs["input"] == "input.bp"
+    @test inputs["output"] == "output.bp"
+    @test inputs["N"] == 1000
+    @test inputs["output_inputdata"] == true
+end

--- a/source/julia/GrayScott.jl/test/unit/helper/unit-helperMPI.jl
+++ b/source/julia/GrayScott.jl/test/unit/helper/unit-helperMPI.jl
@@ -2,9 +2,11 @@
 import Test: @testset, @test, @test_throws
 import GrayScott: Helper
 
-#@testset "unit-Helper.bcast_file" begin
-config_file = joinpath(dirname(Base.active_project()), "examples",
-                       "settings-files.json")
-@show config_file
-Helper.bcast_file(config_file, MPI.COMM_WORLD)
-#end
+@testset "unit-Helper.bcast_file_contents" begin
+    config_file = joinpath(dirname(Base.active_project()), "examples",
+                           "settings-files.json")
+
+    file_contents = Helper.bcast_file_contents(config_file, MPI.COMM_WORLD)
+    file_contents_expected = String(read(open(config_file, "r")))
+    @test file_contents == file_contents_expected
+end

--- a/source/julia/GrayScott.jl/test/unit/helper/unit-helperMPI.jl
+++ b/source/julia/GrayScott.jl/test/unit/helper/unit-helperMPI.jl
@@ -1,0 +1,10 @@
+
+import Test: @testset, @test, @test_throws
+import GrayScott: Helper
+
+#@testset "unit-Helper.bcast_file" begin
+config_file = joinpath(dirname(Base.active_project()), "examples",
+                       "settings-files.json")
+@show config_file
+Helper.bcast_file(config_file, MPI.COMM_WORLD)
+#end

--- a/source/julia/GrayScott.jl/test/unit/simulation/unit-IO.jl
+++ b/source/julia/GrayScott.jl/test/unit/simulation/unit-IO.jl
@@ -1,0 +1,36 @@
+
+import Test: @testset, @test, @test_throws
+
+import ADIOS2
+
+# import submodule
+import GrayScott: IO
+# import types
+import GrayScott: Settings, MPICartDomain, Fields
+
+@testset "unit-IO.init" begin
+    settings = Settings()
+    mpi_cart_domain = MPICartDomain()
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
+
+    @test eltype(fields.u) == Float32
+    @test eltype(fields.v) == Float32
+
+    stream = IO.init(settings, mpi_cart_domain, fields)
+
+    @test ADIOS2.name(stream.engine) == "foo.bp"
+    IO.close!(stream)
+
+    # @TODO: needs to be done from rank==0 only 
+    # Base.Filesystem.rm("foo.bp", force = true, recursive = true)
+end
+
+@testset "unit-IO.write" begin
+    settings = Settings()
+    settings.L = 6
+    mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
+    stream = IO.init(settings, mpi_cart_domain, fields)
+    IO.write_step!(stream, Int32(0), fields)
+    IO.close!(stream)
+end

--- a/source/julia/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
+++ b/source/julia/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
@@ -2,6 +2,12 @@
 import Test: @testset, @test, @test_throws
 import GrayScott: Inputs
 
+@testset "unit-Inputs.get_settings" begin
+    config_file = joinpath(dirname(Base.active_project()), "examples",
+                           "settings-files.json")
+    Inputs.get_settings([config_file], MPI.COMM_WORLD)
+end
+
 @testset "unit-Inputs._parse_args" begin
     @test Inputs._parse_args(["hello.json"]) == "hello.json"
 

--- a/source/julia/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
+++ b/source/julia/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
@@ -1,0 +1,9 @@
+
+import Test: @testset, @test, @test_throws
+import GrayScott: Inputs
+
+@testset "unit-Inputs._parse_args" begin
+    @test Inputs._parse_args(["hello.json"]) == "hello.json"
+
+    @test_throws(ArgumentError, Inputs._parse_args(["hello.nojson"]))
+end

--- a/source/julia/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
+++ b/source/julia/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
@@ -2,14 +2,14 @@
 import Test: @testset, @test, @test_throws
 import GrayScott: Inputs
 
+# Unfortunately due to MPI being a Singleton, single MPI.Init()
+# these unit tests don't run as independent files
+
 @testset "unit-Inputs.get_settings" begin
     config_file = joinpath(dirname(Base.active_project()), "examples",
                            "settings-files.json")
     Inputs.get_settings([config_file], MPI.COMM_WORLD)
-end
 
-@testset "unit-Inputs._parse_args" begin
-    @test Inputs._parse_args(["hello.json"]) == "hello.json"
-
-    @test_throws(ArgumentError, Inputs._parse_args(["hello.nojson"]))
+    @test_throws(ArgumentError,
+                 Inputs.get_settings(["hello.nojson"], MPI.COMM_WORLD))
 end

--- a/source/julia/GrayScott.jl/test/unit/simulation/unit-Simulation.jl
+++ b/source/julia/GrayScott.jl/test/unit/simulation/unit-Simulation.jl
@@ -1,0 +1,34 @@
+
+import Test: @testset, @test, @test_throws
+# import submodule
+import GrayScott: Simulation
+# import types
+import GrayScott: Settings, MPICartDomain, Fields
+
+# Unfortunately due to MPI being a Singleton, single MPI.Init()
+# these unit tests don't run as independent files
+
+@testset "unit-Simulation.init" begin
+    settings = Settings()
+    mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
+
+    @test typeof(fields) == Fields{Float32, 3, Array{Float32, 3}}
+end
+
+@testset "unit-Simulation.iterate" begin
+    settings = Settings()
+    settings.L = 2
+    mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
+
+    Simulation.iterate!(fields, settings, mpi_cart_domain)
+
+    if verbose
+        sleep(0.01)
+        rank = MPI.Comm_rank(MPI.COMM_WORLD)
+        @show rank, fields.v
+    end
+end
+
+#end

--- a/source/julia/GrayScott.jl/test/unit/simulation/unit-Simulation_CUDA.jl
+++ b/source/julia/GrayScott.jl/test/unit/simulation/unit-Simulation_CUDA.jl
@@ -1,0 +1,28 @@
+
+import Test: @testset, @test, @test_throws
+# import submodule
+import GrayScott: Simulation
+# import types
+import GrayScott: Settings, MPICartDomain, Fields
+
+@testset "unit-Simulation.init_fields-cuda" begin
+    function test_init_cuda(L)
+        settings = Settings()
+        settings.L = L
+        mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
+
+        fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
+
+        settings.backend = "CUDA"
+        fields_cuda = Simulation.init_fields(settings, mpi_cart_domain, Float32)
+
+        @test fields.u ≈ Array(fields_cuda.u)
+        @test fields.v ≈ Array(fields_cuda.v)
+    end
+
+    test_init_cuda(8)
+    test_init_cuda(16)
+    test_init_cuda(32)
+    test_init_cuda(64)
+    test_init_cuda(128)
+end


### PR DESCRIPTION
1. Simulation only: CPU threads, CUDA and AMDGPU (Rocm) backend
2. Produces a VTX and FIDES compatible bp file with ADIOS2.jl
3. Adds README
4. Summit and Crusher configuration scripts and instructions
5. Added unit tests (CI to be added later)

To do:
1. Add analysis code using Julia (PDF analysis and plotting)
2. AMDGPU randn is still needed