### PR TITLE
Fix typo `calculte` -> `calculate`

### DIFF
--- a/source/julia/GrayScott.jl/src/simulation/Simulation_AMDGPU.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Simulation_AMDGPU.jl
@@ -111,21 +111,21 @@ function _calculate!(fields::Fields{T, N, <:AMDGPU.ROCArray{T, N}},
     threads = (16, 16)
     blocks = (settings.L, settings.L)
 
-    AMDGPU.wait(AMDGPU.@roc groupsize=threads gridsize=grid _calculte_kernel_amdgpu!(fields.u,
-                                                                                     fields.v,
-                                                                                     fields.u_temp,
-                                                                                     fields.v_temp,
-                                                                                     roc_sizes,
-                                                                                     Du,
-                                                                                     Dv,
-                                                                                     F,
-                                                                                     K,
-                                                                                     noise,
-                                                                                     dt))
+    AMDGPU.wait(AMDGPU.@roc groupsize=threads gridsize=grid _calculate_kernel_amdgpu!(fields.u,
+                                                                                      fields.v,
+                                                                                      fields.u_temp,
+                                                                                      fields.v_temp,
+                                                                                      roc_sizes,
+                                                                                      Du,
+                                                                                      Dv,
+                                                                                      F,
+                                                                                      K,
+                                                                                      noise,
+                                                                                      dt))
 end
 
-function _calculte_kernel_amdgpu!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
-                                  noise, dt)
+function _calculate_kernel_amdgpu!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
+                                   noise, dt)
 
     # local coordinates (this are 1-index already)
     k = (AMDGPU.workgroupIdx().x - Int32(1)) * AMDGPU.workgroupDim().x +

--- a/source/julia/GrayScott.jl/src/simulation/Simulation_CUDA.jl
+++ b/source/julia/GrayScott.jl/src/simulation/Simulation_CUDA.jl
@@ -96,8 +96,8 @@ end
 function _calculate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
                      settings::Settings,
                      mcd::MPICartDomain) where {T, N}
-    function _calculte_kernel!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
-                               noise, dt)
+    function _calculate_kernel!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
+                                noise, dt)
 
         # local coordinates (this are 1-index already)
         k = (CUDA.blockIdx().x - Int32(1)) * CUDA.blockDim().x +
@@ -138,13 +138,13 @@ function _calculate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
     threads = (16, 16)
     blocks = (settings.L, settings.L)
 
-    CUDA.@cuda threads=threads blocks=blocks _calculte_kernel!(fields.u,
-                                                               fields.v,
-                                                               fields.u_temp,
-                                                               fields.v_temp,
-                                                               cu_sizes,
-                                                               Du, Dv, F, K,
-                                                               noise, dt)
+    CUDA.@cuda threads=threads blocks=blocks _calculate_kernel!(fields.u,
+                                                                fields.v,
+                                                                fields.u_temp,
+                                                                fields.v_temp,
+                                                                cu_sizes,
+                                                                Du, Dv, F, K,
+                                                                noise, dt)
     CUDA.synchronize()
 end
 


### PR DESCRIPTION
It's just a minor typo but I stumbled across it while reading through your examples and I could not *not* submit a PR to try to fix it 😬