### PR TITLE
Fix Gray-Scott bug related to data integrity for the U variable

### DIFF
--- a/source/gpu/gray-scott-kokkos/gray-scott.cpp
+++ b/source/gpu/gray-scott-kokkos/gray-scott.cpp
@@ -25,9 +25,7 @@ void GrayScott::iterate()
 {
     auto temp_u = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, u);
     auto temp_v = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, v);
-    std::vector<double> vu(temp_u.data(), temp_u.data() + temp_u.size());
-    std::vector<double> vv(temp_v.data(), temp_v.data() + temp_v.size());
-    exchange(vu, vv);
+    exchange(temp_u, temp_v);
     Kokkos::deep_copy(u, temp_u);
     Kokkos::deep_copy(v, temp_v);
 
@@ -258,49 +256,49 @@ void GrayScott::init_mpi()
     MPI_Type_commit(&yz_face_type);
 }
 
-void GrayScott::exchange_xy(std::vector<double> &local_data) const
+void GrayScott::exchange_xy(Kokkos::View<double ***> local_data) const
 {
     MPI_Status st;
 
     // Send XY face z=size_z to north and receive z=0 from south
-    MPI_Sendrecv(&local_data[l2i(1, 0, size_z)], 1, xy_face_type, north, 1,
-                 &local_data[l2i(1, 0, 0)], 1, xy_face_type, south, 1,
+    MPI_Sendrecv(&local_data.data()[l2i(1, 0, size_z)], 1, xy_face_type, north, 1,
+                 &local_data.data()[l2i(1, 0, 0)], 1, xy_face_type, south, 1,
                  cart_comm, &st);
     // Send XY face z=1 to south and receive z=size_z+1 from north
-    MPI_Sendrecv(&local_data[l2i(1, 0, 1)], 1, xy_face_type, south, 1,
-                 &local_data[l2i(1, 0, size_z + 1)], 1, xy_face_type, north, 1,
+    MPI_Sendrecv(&local_data.data()[l2i(1, 0, 1)], 1, xy_face_type, south, 1,
+                 &local_data.data()[l2i(1, 0, size_z + 1)], 1, xy_face_type, north, 1,
                  cart_comm, &st);
 }
 
-void GrayScott::exchange_xz(std::vector<double> &local_data) const
+void GrayScott::exchange_xz(Kokkos::View<double ***> local_data) const
 {
     MPI_Status st;
 
     // Send XZ face y=size_y to up and receive y=0 from down
-    MPI_Sendrecv(&local_data[l2i(1, size_y, 1)], 1, xz_face_type, up, 2,
-                 &local_data[l2i(1, 0, 1)], 1, xz_face_type, down, 2, cart_comm,
+    MPI_Sendrecv(&local_data.data()[l2i(1, size_y, 1)], 1, xz_face_type, up, 2,
+                 &local_data.data()[l2i(1, 0, 1)], 1, xz_face_type, down, 2, cart_comm,
                  &st);
     // Send XZ face y=1 to down and receive y=size_y+1 from up
-    MPI_Sendrecv(&local_data[l2i(1, 1, 1)], 1, xz_face_type, down, 2,
-                 &local_data[l2i(1, size_y + 1, 1)], 1, xz_face_type, up, 2,
+    MPI_Sendrecv(&local_data.data()[l2i(1, 1, 1)], 1, xz_face_type, down, 2,
+                 &local_data.data()[l2i(1, size_y + 1, 1)], 1, xz_face_type, up, 2,
                  cart_comm, &st);
 }
 
-void GrayScott::exchange_yz(std::vector<double> &local_data) const
+void GrayScott::exchange_yz(Kokkos::View<double ***> local_data) const
 {
     MPI_Status st;
 
     // Send YZ face x=size_x to east and receive x=0 from west
-    MPI_Sendrecv(&local_data[l2i(size_x, 0, 0)], 1, yz_face_type, east, 3,
-                 &local_data[l2i(0, 0, 0)], 1, yz_face_type, west, 3, cart_comm,
+    MPI_Sendrecv(&local_data.data()[l2i(size_x, 0, 0)], 1, yz_face_type, east, 3,
+                 &local_data.data()[l2i(0, 0, 0)], 1, yz_face_type, west, 3, cart_comm,
                  &st);
     // Send YZ face x=1 to west and receive x=size_x+1 from east
-    MPI_Sendrecv(&local_data[l2i(1, 0, 0)], 1, yz_face_type, west, 3,
-                 &local_data[l2i(size_x + 1, 0, 0)], 1, yz_face_type, east, 3,
+    MPI_Sendrecv(&local_data.data()[l2i(1, 0, 0)], 1, yz_face_type, west, 3,
+                 &local_data.data()[l2i(size_x + 1, 0, 0)], 1, yz_face_type, east, 3,
                  cart_comm, &st);
 }
 
-void GrayScott::exchange(std::vector<double> &u, std::vector<double> &v) const
+void GrayScott::exchange(Kokkos::View<double ***> u, Kokkos::View<double ***> v) const
 {
     exchange_xy(u);
     exchange_xz(u);

--- a/source/gpu/gray-scott-kokkos/gray-scott.cpp
+++ b/source/gpu/gray-scott-kokkos/gray-scott.cpp
@@ -107,25 +107,23 @@ void GrayScott::init_field()
     auto const temp_u = u;
     auto const temp_v = v;
     size_t const ox = offset_x, oy = offset_y, oz = offset_z;
-    size_t const sx = size_x, sy = size_y, sz = size_z;
+    size_t const sx = size_x, sy = size_y;
+    auto const min_z = std::max(L / 2 - d, offset_z);
+    auto const max_z = std::min(L / 2 + d, offset_z + size_z);
     Kokkos::parallel_for(
-        "init_buffers", Kokkos::RangePolicy<>(L / 2 - d, L / 2 + d),
+        "init_buffers", Kokkos::RangePolicy<>(min_z, max_z),
         KOKKOS_LAMBDA(int z) {
             for (int y = L / 2 - d; y < L / 2 + d; y++)
             {
+                if (y < oy)
+                    continue;
+                if (y >= oy + sy)
+                    continue;
                 for (int x = L / 2 - d; x < L / 2 + d; x++)
                 {
                     if (x < ox)
                         continue;
                     if (x >= ox + sx)
-                        continue;
-                    if (y < oy)
-                        continue;
-                    if (y >= oy + sy)
-                        continue;
-                    if (z < oz)
-                        continue;
-                    if (z >= oz + sz)
                         continue;
                     temp_u(x - ox + 1, y - oy + 1, z - oz + 1) = 0.25;
                     temp_v(x - ox + 1, y - oy + 1, z - oz + 1) = 0.33;

--- a/source/gpu/gray-scott-kokkos/gray-scott.h
+++ b/source/gpu/gray-scott-kokkos/gray-scott.h
@@ -1,10 +1,10 @@
 #ifndef __GRAY_SCOTT_H__
 #define __GRAY_SCOTT_H__
 
-#include <random>
 #include <vector>
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
 #include <mpi.h>
 
 #include "settings.h"
@@ -52,9 +52,9 @@ public:
     MPI_Datatype xz_face_type;
     MPI_Datatype yz_face_type;
 
-    std::random_device rand_dev;
-    std::mt19937 mt_gen;
-    std::uniform_real_distribution<double> uniform_dist;
+	using RandomPool =
+        Kokkos::Random_XorShift64_Pool<Kokkos::DefaultExecutionSpace>;
+    RandomPool rand_pool;
 
     // Setup cartesian communicator data types
     void init_mpi();

--- a/source/gpu/gray-scott-kokkos/gray-scott.h
+++ b/source/gpu/gray-scott-kokkos/gray-scott.h
@@ -65,13 +65,13 @@ public:
     void calc();
 
     // Exchange faces with neighbors
-    void exchange(std::vector<double> &u, std::vector<double> &v) const;
+    void exchange(Kokkos::View<double ***> u, Kokkos::View<double ***> v) const;
     // Exchange XY faces with north/south
-    void exchange_xy(std::vector<double> &local_data) const;
+    void exchange_xy(Kokkos::View<double ***> local_data) const;
     // Exchange XZ faces with up/down
-    void exchange_xz(std::vector<double> &local_data) const;
+    void exchange_xz(Kokkos::View<double ***> local_data) const;
     // Exchange YZ faces with west/east
-    void exchange_yz(std::vector<double> &local_data) const;
+    void exchange_yz(Kokkos::View<double ***> local_data) const;
 
     // Return a copy of data with ghosts removed
     Kokkos::View<double ***>


### PR DESCRIPTION
Closes #79 

Tested on Treads and Cuda backends, the data generated by the Kokkos and CPU version are identical.

Left is Kokkos, right is CPU

<img width="1090" alt="Screenshot 2023-06-10 at 10 40 13 PM" src="https://github.com/ornladios/ADIOS2-Examples/assets/16229479/8ffe551b-f847-47d1-9281-6a92d72065a8">

PDF plot:
<img width="1103" alt="Screenshot 2023-06-10 at 10 40 36 PM" src="https://github.com/ornladios/ADIOS2-Examples/assets/16229479/958d278c-c1c8-4de9-8bb5-cfcfd3e1ea29">
