### PR TITLE
Temporary bug fix in Gray-Scott with Kokkos when running on multiple nodes

### DIFF
--- a/source/gpu/gray-scott-kokkos/gray-scott.cpp
+++ b/source/gpu/gray-scott-kokkos/gray-scott.cpp
@@ -265,7 +265,8 @@ void GrayScott::init_mpi()
 }
 
 void GrayScott::exchange_xy(
-    Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const
+    Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace> local_data)
+    const
 {
     MPI_Status st;
 
@@ -280,7 +281,8 @@ void GrayScott::exchange_xy(
 }
 
 void GrayScott::exchange_xz(
-    Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const
+    Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace> local_data)
+    const
 {
     MPI_Status st;
 
@@ -295,7 +297,8 @@ void GrayScott::exchange_xz(
 }
 
 void GrayScott::exchange_yz(
-    Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const
+    Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace> local_data)
+    const
 {
     MPI_Status st;
 
@@ -309,8 +312,9 @@ void GrayScott::exchange_yz(
                  east, 3, cart_comm, &st);
 }
 
-void GrayScott::exchange(Kokkos::View<double ***, Kokkos::LayoutLeft> u,
-                         Kokkos::View<double ***, Kokkos::LayoutLeft> v) const
+void GrayScott::exchange(
+    Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace> u,
+    Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace> v) const
 {
     exchange_xy(u);
     exchange_xz(u);

--- a/source/gpu/gray-scott-kokkos/gray-scott.cpp
+++ b/source/gpu/gray-scott-kokkos/gray-scott.cpp
@@ -35,8 +35,8 @@ void GrayScott::iterate()
     std::swap(v, v2);
 }
 
-void GrayScott::restart(Kokkos::View<double ***> &u_in,
-                        Kokkos::View<double ***> &v_in)
+void GrayScott::restart(Kokkos::View<double ***, Kokkos::LayoutLeft> &u_in,
+                        Kokkos::View<double ***, Kokkos::LayoutLeft> &v_in)
 {
     auto const expected_len = (size_x + 2) * (size_y + 2) * (size_z + 2);
     if (u_in.size() == expected_len)
@@ -53,40 +53,50 @@ void GrayScott::restart(Kokkos::View<double ***> &u_in,
     }
 }
 
-const Kokkos::View<double ***> GrayScott::u_ghost() const { return u; }
+const Kokkos::View<double ***, Kokkos::LayoutLeft> GrayScott::u_ghost() const
+{
+    return u;
+}
 
-const Kokkos::View<double ***> GrayScott::v_ghost() const { return v; }
+const Kokkos::View<double ***, Kokkos::LayoutLeft> GrayScott::v_ghost() const
+{
+    return v;
+}
 
-Kokkos::View<double ***> GrayScott::u_noghost() const
+Kokkos::View<double ***, Kokkos::LayoutLeft> GrayScott::u_noghost() const
 {
     return data_noghost(u);
 }
 
-Kokkos::View<double ***> GrayScott::v_noghost() const
+Kokkos::View<double ***, Kokkos::LayoutLeft> GrayScott::v_noghost() const
 {
     return data_noghost(v);
 }
 
-void GrayScott::u_noghost(Kokkos::View<double ***> u_no_ghost) const
+void GrayScott::u_noghost(
+    Kokkos::View<double ***, Kokkos::LayoutLeft> u_no_ghost) const
 {
     data_noghost(u, u_no_ghost);
 }
 
-void GrayScott::v_noghost(Kokkos::View<double ***> v_no_ghost) const
+void GrayScott::v_noghost(
+    Kokkos::View<double ***, Kokkos::LayoutLeft> v_no_ghost) const
 {
     data_noghost(v, v_no_ghost);
 }
 
-Kokkos::View<double ***>
-GrayScott::data_noghost(const Kokkos::View<double ***> &data) const
+Kokkos::View<double ***, Kokkos::LayoutLeft> GrayScott::data_noghost(
+    const Kokkos::View<double ***, Kokkos::LayoutLeft> &data) const
 {
-    Kokkos::View<double ***> buf("noghost_temp", size_x, size_y, size_z);
+    Kokkos::View<double ***, Kokkos::LayoutLeft> buf("noghost_temp", size_x,
+                                                     size_y, size_z);
     data_no_ghost_common(data, buf);
     return buf;
 }
 
-void GrayScott::data_noghost(const Kokkos::View<double ***> &data,
-                             Kokkos::View<double ***> data_no_ghost) const
+void GrayScott::data_noghost(
+    const Kokkos::View<double ***, Kokkos::LayoutLeft> &data,
+    Kokkos::View<double ***, Kokkos::LayoutLeft> data_no_ghost) const
 {
     data_no_ghost_common(data, data_no_ghost);
 }
@@ -143,9 +153,9 @@ void GrayScott::calc()
     auto const dt = settings.dt;
     auto const F = settings.F;
     auto const k = settings.k;
-	auto const noise = settings.noise;
+    auto const noise = settings.noise;
     size_t const sx = size_x, sy = size_y, sz = size_z;
-	auto const random_pool = rand_pool;
+    auto const random_pool = rand_pool;
     Kokkos::parallel_for(
         "calc_gray_scott", Kokkos::RangePolicy<>(1, sz + 1),
         KOKKOS_LAMBDA(int z) {
@@ -254,49 +264,53 @@ void GrayScott::init_mpi()
     MPI_Type_commit(&yz_face_type);
 }
 
-void GrayScott::exchange_xy(Kokkos::View<double ***> local_data) const
+void GrayScott::exchange_xy(
+    Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const
 {
     MPI_Status st;
 
     // Send XY face z=size_z to north and receive z=0 from south
-    MPI_Sendrecv(&local_data.data()[l2i(1, 0, size_z)], 1, xy_face_type, north, 1,
-                 &local_data.data()[l2i(1, 0, 0)], 1, xy_face_type, south, 1,
+    MPI_Sendrecv(&local_data.data()[l2i(1, 0, size_z)], 1, xy_face_type, north,
+                 1, &local_data.data()[l2i(1, 0, 0)], 1, xy_face_type, south, 1,
                  cart_comm, &st);
     // Send XY face z=1 to south and receive z=size_z+1 from north
     MPI_Sendrecv(&local_data.data()[l2i(1, 0, 1)], 1, xy_face_type, south, 1,
-                 &local_data.data()[l2i(1, 0, size_z + 1)], 1, xy_face_type, north, 1,
-                 cart_comm, &st);
+                 &local_data.data()[l2i(1, 0, size_z + 1)], 1, xy_face_type,
+                 north, 1, cart_comm, &st);
 }
 
-void GrayScott::exchange_xz(Kokkos::View<double ***> local_data) const
+void GrayScott::exchange_xz(
+    Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const
 {
     MPI_Status st;
 
     // Send XZ face y=size_y to up and receive y=0 from down
     MPI_Sendrecv(&local_data.data()[l2i(1, size_y, 1)], 1, xz_face_type, up, 2,
-                 &local_data.data()[l2i(1, 0, 1)], 1, xz_face_type, down, 2, cart_comm,
-                 &st);
+                 &local_data.data()[l2i(1, 0, 1)], 1, xz_face_type, down, 2,
+                 cart_comm, &st);
     // Send XZ face y=1 to down and receive y=size_y+1 from up
     MPI_Sendrecv(&local_data.data()[l2i(1, 1, 1)], 1, xz_face_type, down, 2,
-                 &local_data.data()[l2i(1, size_y + 1, 1)], 1, xz_face_type, up, 2,
-                 cart_comm, &st);
+                 &local_data.data()[l2i(1, size_y + 1, 1)], 1, xz_face_type, up,
+                 2, cart_comm, &st);
 }
 
-void GrayScott::exchange_yz(Kokkos::View<double ***> local_data) const
+void GrayScott::exchange_yz(
+    Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const
 {
     MPI_Status st;
 
     // Send YZ face x=size_x to east and receive x=0 from west
-    MPI_Sendrecv(&local_data.data()[l2i(size_x, 0, 0)], 1, yz_face_type, east, 3,
-                 &local_data.data()[l2i(0, 0, 0)], 1, yz_face_type, west, 3, cart_comm,
-                 &st);
+    MPI_Sendrecv(&local_data.data()[l2i(size_x, 0, 0)], 1, yz_face_type, east,
+                 3, &local_data.data()[l2i(0, 0, 0)], 1, yz_face_type, west, 3,
+                 cart_comm, &st);
     // Send YZ face x=1 to west and receive x=size_x+1 from east
     MPI_Sendrecv(&local_data.data()[l2i(1, 0, 0)], 1, yz_face_type, west, 3,
-                 &local_data.data()[l2i(size_x + 1, 0, 0)], 1, yz_face_type, east, 3,
-                 cart_comm, &st);
+                 &local_data.data()[l2i(size_x + 1, 0, 0)], 1, yz_face_type,
+                 east, 3, cart_comm, &st);
 }
 
-void GrayScott::exchange(Kokkos::View<double ***> u, Kokkos::View<double ***> v) const
+void GrayScott::exchange(Kokkos::View<double ***, Kokkos::LayoutLeft> u,
+                         Kokkos::View<double ***, Kokkos::LayoutLeft> v) const
 {
     exchange_xy(u);
     exchange_xz(u);
@@ -308,8 +322,8 @@ void GrayScott::exchange(Kokkos::View<double ***> u, Kokkos::View<double ***> v)
 }
 
 void GrayScott::data_no_ghost_common(
-    const Kokkos::View<double ***> &data,
-    Kokkos::View<double ***> data_no_ghost) const
+    const Kokkos::View<double ***, Kokkos::LayoutLeft> &data,
+    Kokkos::View<double ***, Kokkos::LayoutLeft> data_no_ghost) const
 {
     auto const sx = size_x;
     auto const sy = size_y;

--- a/source/gpu/gray-scott-kokkos/gray-scott.h
+++ b/source/gpu/gray-scott-kokkos/gray-scott.h
@@ -67,17 +67,22 @@ public:
     void calc();
 
     // Exchange faces with neighbors
-    void exchange(Kokkos::View<double ***, Kokkos::LayoutLeft> u,
-                  Kokkos::View<double ***, Kokkos::LayoutLeft> v) const;
+    void
+    exchange(Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace> u,
+             Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace> v)
+        const;
     // Exchange XY faces with north/south
     void
-    exchange_xy(Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const;
+    exchange_xy(Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace>
+                    local_data) const;
     // Exchange XZ faces with up/down
     void
-    exchange_xz(Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const;
+    exchange_xz(Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace>
+                    local_data) const;
     // Exchange YZ faces with west/east
     void
-    exchange_yz(Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const;
+    exchange_yz(Kokkos::View<double ***, Kokkos::LayoutLeft, Kokkos::HostSpace>
+                    local_data) const;
 
     // Return a copy of data with ghosts removed
     Kokkos::View<double ***, Kokkos::LayoutLeft> data_noghost(

--- a/source/gpu/gray-scott-kokkos/gray-scott.h
+++ b/source/gpu/gray-scott-kokkos/gray-scott.h
@@ -26,21 +26,23 @@ public:
 
     void init();
     void iterate();
-    void restart(Kokkos::View<double ***> &u, Kokkos::View<double ***> &v);
+    void restart(Kokkos::View<double ***, Kokkos::LayoutLeft> &u,
+                 Kokkos::View<double ***, Kokkos::LayoutLeft> &v);
 
-    const Kokkos::View<double ***> u_ghost() const;
-    const Kokkos::View<double ***> v_ghost() const;
+    const Kokkos::View<double ***, Kokkos::LayoutLeft> u_ghost() const;
+    const Kokkos::View<double ***, Kokkos::LayoutLeft> v_ghost() const;
 
-    Kokkos::View<double ***> u_noghost() const;
-    Kokkos::View<double ***> v_noghost() const;
+    Kokkos::View<double ***, Kokkos::LayoutLeft> u_noghost() const;
+    Kokkos::View<double ***, Kokkos::LayoutLeft> v_noghost() const;
 
-    void u_noghost(Kokkos::View<double ***> u_no_ghost) const;
-    void v_noghost(Kokkos::View<double ***> v_no_ghost) const;
+    void
+    u_noghost(Kokkos::View<double ***, Kokkos::LayoutLeft> u_no_ghost) const;
+    void
+    v_noghost(Kokkos::View<double ***, Kokkos::LayoutLeft> v_no_ghost) const;
 
     Settings settings;
 
-    using mem_space = Kokkos::DefaultExecutionSpace::memory_space;
-    Kokkos::View<double ***, mem_space> u, v, u2, v2;
+    Kokkos::View<double ***, Kokkos::LayoutLeft> u, v, u2, v2;
 
     int rank, procs;
     int west, east, up, down, north, south;
@@ -52,7 +54,7 @@ public:
     MPI_Datatype xz_face_type;
     MPI_Datatype yz_face_type;
 
-	using RandomPool =
+    using RandomPool =
         Kokkos::Random_XorShift64_Pool<Kokkos::DefaultExecutionSpace>;
     RandomPool rand_pool;
 
@@ -65,21 +67,26 @@ public:
     void calc();
 
     // Exchange faces with neighbors
-    void exchange(Kokkos::View<double ***> u, Kokkos::View<double ***> v) const;
+    void exchange(Kokkos::View<double ***, Kokkos::LayoutLeft> u,
+                  Kokkos::View<double ***, Kokkos::LayoutLeft> v) const;
     // Exchange XY faces with north/south
-    void exchange_xy(Kokkos::View<double ***> local_data) const;
+    void
+    exchange_xy(Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const;
     // Exchange XZ faces with up/down
-    void exchange_xz(Kokkos::View<double ***> local_data) const;
+    void
+    exchange_xz(Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const;
     // Exchange YZ faces with west/east
-    void exchange_yz(Kokkos::View<double ***> local_data) const;
+    void
+    exchange_yz(Kokkos::View<double ***, Kokkos::LayoutLeft> local_data) const;
 
     // Return a copy of data with ghosts removed
-    Kokkos::View<double ***>
-    data_noghost(const Kokkos::View<double ***> &data) const;
+    Kokkos::View<double ***, Kokkos::LayoutLeft> data_noghost(
+        const Kokkos::View<double ***, Kokkos::LayoutLeft> &data) const;
 
     // pointer version
-    void data_noghost(const Kokkos::View<double ***> &data,
-                      Kokkos::View<double ***> no_ghost) const;
+    void
+    data_noghost(const Kokkos::View<double ***, Kokkos::LayoutLeft> &data,
+                 Kokkos::View<double ***, Kokkos::LayoutLeft> no_ghost) const;
 
     // Convert local coordinate to local index
     KOKKOS_FUNCTION int l2i(int x, int y, int z) const
@@ -87,8 +94,9 @@ public:
         return x + y * (size_x + 2) + z * (size_x + 2) * (size_y + 2);
     }
 
-    void data_no_ghost_common(const Kokkos::View<double ***> &data,
-                              Kokkos::View<double ***> data_no_ghost) const;
+    void data_no_ghost_common(
+        const Kokkos::View<double ***, Kokkos::LayoutLeft> &data,
+        Kokkos::View<double ***, Kokkos::LayoutLeft> data_no_ghost) const;
 };
 
 #endif

--- a/source/gpu/gray-scott-kokkos/restart.cpp
+++ b/source/gpu/gray-scott-kokkos/restart.cpp
@@ -74,7 +74,8 @@ int ReadRestart(MPI_Comm comm, const Settings &settings, GrayScott &sim,
         size_t Y = sim.size_y + 2;
         size_t Z = sim.size_z + 2;
         size_t R = static_cast<size_t>(rank);
-        Kokkos::View<double ***> u("u", X, Y, Z), v("v", X, Y, Z);
+        Kokkos::View<double ***, Kokkos::LayoutLeft> u("u", X, Y, Z),
+            v("v", X, Y, Z);
 
         var_u.SetSelection({{R, 0, 0, 0}, {1, X, Y, Z}});
         var_v.SetSelection({{R, 0, 0, 0}, {1, X, Y, Z}});

--- a/source/gpu/gray-scott-kokkos/writer.cpp
+++ b/source/gpu/gray-scott-kokkos/writer.cpp
@@ -113,8 +113,8 @@ void Writer::write(int step, const GrayScott &sim)
 
     if (settings.adios_memory_selection)
     {
-        const Kokkos::View<double ***> u = sim.u_ghost();
-        const Kokkos::View<double ***> v = sim.v_ghost();
+        const Kokkos::View<double ***, Kokkos::LayoutLeft> u = sim.u_ghost();
+        const Kokkos::View<double ***, Kokkos::LayoutLeft> v = sim.v_ghost();
 
         writer.BeginStep();
         writer.Put<int>(var_step, &step);
@@ -129,8 +129,8 @@ void Writer::write(int step, const GrayScott &sim)
     }
     else
     {
-        Kokkos::View<double ***> u = sim.u_noghost();
-        Kokkos::View<double ***> v = sim.v_noghost();
+        Kokkos::View<double ***, Kokkos::LayoutLeft> u = sim.u_noghost();
+        Kokkos::View<double ***, Kokkos::LayoutLeft> v = sim.v_noghost();
 
         writer.BeginStep();
         writer.Put<int>(var_step, &step);


### PR DESCRIPTION
The default layout for Kokkos View is `LayoutLeft` for CUDA backend and `RightLayout` for CPU. Since the initial code I used was assuming a fixed layout for the sendrecv in MPI the runs were giving wrong data when using multiple MPI processes on CPU. 

Fixed for now but we need to figure out an automatic way of adapting to the default layout without forcing one (since we might get bad performance on some architectures)