### PR TITLE
Update the python hello world example to work with BP5

### DIFF
--- a/source/python/hello-world/hello-world.py
+++ b/source/python/hello-world/hello-world.py
@@ -33,8 +33,10 @@ def reader(ad):
     """read a string from to a bp file"""
     io = ad.DeclareIO("hello-world-reader")
     r = io.Open(DATA_FILENAME, adios2.Mode.Read)
+    r.BeginStep()
     var_greeting = io.InquireVariable("Greeting")
     message = r.Get(var_greeting)
+    r.EndStep()
     return message
 
 


### PR DESCRIPTION
The default engine in the latest ADIOS2 release is BP5 which requires calls to the engine to be between `BeginStep` and `EndStep`. The python code written for BP4 needs to be updated. 